### PR TITLE
add the missing lifetimes

### DIFF
--- a/src/style/enums/attribute.rs
+++ b/src/style/enums/attribute.rs
@@ -114,7 +114,7 @@ pub enum Attribute {
 }
 
 impl Display for Attribute {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> std::result::Result<(), std::fmt::Error> {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
         write!(f, "{}", SetAttr(*self))?;
         Ok(())
     }

--- a/src/style/enums/colored.rs
+++ b/src/style/enums/colored.rs
@@ -29,7 +29,7 @@ pub enum Colored {
 }
 
 impl Display for Colored {
-    fn fmt(&self, _f: &mut ::std::fmt::Formatter) -> std::result::Result<(), std::fmt::Error> {
+    fn fmt(&self, _f: &mut ::std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
         let colored_terminal = color();
 
         match *self {

--- a/src/style/styledobject.rs
+++ b/src/style/styledobject.rs
@@ -52,7 +52,7 @@ impl<'a, D: Display + 'a + Clone> StyledObject<D> {
 }
 
 impl<D: Display + Clone> Display for StyledObject<D> {
-    fn fmt(&self, f: &mut Formatter) -> result::Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> result::Result<(), fmt::Error> {
         let mut reset = false;
 
         if let Some(bg) = self.object_style.bg_color {

--- a/src/utils/macros.rs
+++ b/src/utils/macros.rs
@@ -179,7 +179,7 @@ macro_rules! execute {
 macro_rules! impl_display {
     (for $($t:ty),+) => {
         $(impl ::std::fmt::Display for $t {
-            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::result::Result<(), ::std::fmt::Error> {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::result::Result<(), ::std::fmt::Error> {
                 use $crate::Command;
                 write!(f, "{}", self.ansi_code())
             }


### PR DESCRIPTION
This prevents developers having configured their env for
rust 2018 idioms to be submerged with warnings.