### PR TITLE
Add input::stop_reading_thread() fn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,16 @@
+# master
+
+- New `input::stop_reading_thread()` function
+  - Temporary workaround for the UNIX platform to stop the background
+    reading thread and close the file descriptor
+  - This function will be removed in the next version
+
 # Version 0.13.1
+
 - Async Reader fix, join background thread and avoid looping forever on windows.
 
 # Version 0.13.0
+
 **Major API-change, removed old-api**
 
 - Remove `Crossterm` type

--- a/src/input.rs
+++ b/src/input.rs
@@ -463,3 +463,18 @@ impl Command for DisableMouseCapture {
         input().disable_mouse_mode()
     }
 }
+
+/// Stops the reading thread.
+///
+/// # Notes
+///
+/// This function is a no-op on the Windows platform.
+///
+/// When you call this function on the UNIX platform, all event channel senders
+/// are dropped and as a consequence you have to drop all `SyncReader`/`AsyncReader` readers.
+pub fn stop_reading_thread() {
+    #[cfg(unix)]
+    {
+        sys::unix::stop_reading_thread();
+    }
+}

--- a/src/input/sys/unix.rs
+++ b/src/input/sys/unix.rs
@@ -50,6 +50,10 @@ mod utils {
     }
 }
 
+pub(crate) fn stop_reading_thread() {
+    INTERNAL_EVENT_PROVIDER.lock().unwrap().pause()
+}
+
 /// An internal event provider interface.
 pub(crate) trait InternalEventProvider: Send {
     /// Pauses the provider.
@@ -83,6 +87,12 @@ impl UnixInternalEventChannels {
         UnixInternalEventChannels {
             senders: Arc::new(Mutex::new(vec![])),
         }
+    }
+
+    /// Clears all senders.
+    fn clear(&mut self) {
+        let mut guard = self.senders.lock().unwrap();
+        guard.clear();
     }
 
     /// Sends an `InternalEvent` to all available channels.
@@ -129,6 +139,7 @@ impl InternalEventProvider for UnixInternalEventProvider {
     fn pause(&mut self) {
         // Thread will shutdown on it's own once dropped.
         self.reading_thread = None;
+        self.channels.clear();
     }
 
     /// Creates a new `InternalEvent` receiver and spawns a new reading


### PR DESCRIPTION
This is a temporary workaround to stop the reading thread. Should be released as `0.13.2` and removed later when the new `input` will be available.