### PR TITLE
Replace 'An' with 'A' in docs.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 //! ## Command API
 //!
 //! The command API makes the use of `crossterm` much easier and offers more control over when and how a
-//! command is executed. An command is just an action you can perform on the terminal e.g. cursor movement.
+//! command is executed. A command is just an action you can perform on the terminal e.g. cursor movement.
 //!
 //! The command API offers:
 //!


### PR DESCRIPTION
Use "an" if the word following the article begins with a vowel sound, i.e. "early" or "hour". Use "a" if the word following the following the article begins with a consonant sound, i.e. "command" or "hero".

(this is because the 'h' in "hour" is pronounced as if it didn't exist at all, making the word similar to "our", but the 'h' in "hero" is actually emphasized.)