### PR TITLE
Allow macro trailing comma

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version Master
+
+- `queue!` & `execute!` macros allow trailing comma
+
 # Version 0.13.3
 
 - Remove thread from AsyncReader on Windows.

--- a/src/utils/macros.rs
+++ b/src/utils/macros.rs
@@ -114,20 +114,10 @@ macro_rules! queue {
 
 #[test]
 fn test_queue() {
-    use std::io::{stdout, Write};
     use super::command::Output;
-    assert!(
-        queue!(
-            stdout(),
-            Output("hi"),
-        ).is_ok()
-    );
-    assert!(
-        queue!(
-            stdout(),
-            Output("hi"),
-        ).is_ok()
-    );
+    use std::io::{stdout, Write};
+    assert!(queue!(stdout(), Output("hi"),).is_ok());
+    assert!(queue!(stdout(), Output("hi")).is_ok());
 }
 
 /// Execute one or more command(s)

--- a/src/utils/macros.rs
+++ b/src/utils/macros.rs
@@ -70,7 +70,7 @@ macro_rules! write_cout {
 /// - Queuing might sound that there is some scheduling going on, however, this means that we write to the stdout without flushing which will cause commands to be stored in the buffer without them being written to the terminal.
 #[macro_export]
 macro_rules! queue {
-    ($write:expr, $($command:expr), *) => {{
+    ($write:expr, $($command:expr), * $(,)? ) => {{
         // Silent warning when the macro is used inside the `command` module
         #[allow(unused_imports)]
         use $crate::Command;
@@ -112,6 +112,24 @@ macro_rules! queue {
     }}
 }
 
+#[test]
+fn test_queue() {
+    use std::io::{stdout, Write};
+    use super::command::Output;
+    assert!(
+        queue!(
+            stdout(),
+            Output("hi"),
+        ).is_ok()
+    );
+    assert!(
+        queue!(
+            stdout(),
+            Output("hi"),
+        ).is_ok()
+    );
+}
+
 /// Execute one or more command(s)
 ///
 /// # Parameters
@@ -142,7 +160,7 @@ macro_rules! queue {
 /// Because of that there is no difference between `execute` and `queue` for those windows versions.
 #[macro_export]
 macro_rules! execute {
-    ($write:expr, $($command:expr), *) => {{
+    ($write:expr, $($command:expr), * $(,)? ) => {{
         // Silent warning when the macro is used inside the `command` module
         #[allow(unused_imports)]
         use $crate::{Command, write_cout};

--- a/src/utils/macros.rs
+++ b/src/utils/macros.rs
@@ -204,7 +204,9 @@ macro_rules! impl_from {
 
 #[cfg(test)]
 mod tests {
-    use crate::utils::{command::Command, error::ErrorKind};
+    use crate::utils::command::Command;
+    #[cfg(windows)]
+    use crate::utils::error::ErrorKind;
     use std::io::{stdout, Write};
     pub struct FakeCommand;
 

--- a/src/utils/macros.rs
+++ b/src/utils/macros.rs
@@ -204,10 +204,12 @@ macro_rules! impl_from {
 
 #[cfg(test)]
 mod tests {
+    use std::io::{stdout, Write};
+
     use crate::utils::command::Command;
     #[cfg(windows)]
     use crate::utils::error::ErrorKind;
-    use std::io::{stdout, Write};
+
     pub struct FakeCommand;
 
     impl Command for FakeCommand {

--- a/src/utils/macros.rs
+++ b/src/utils/macros.rs
@@ -220,4 +220,3 @@ mod test {
         assert!(execute!(stdout(), Output("hi")).is_ok());
     }
 }
-

--- a/src/utils/macros.rs
+++ b/src/utils/macros.rs
@@ -112,14 +112,6 @@ macro_rules! queue {
     }}
 }
 
-#[test]
-fn test_queue() {
-    use super::command::Output;
-    use std::io::{stdout, Write};
-    assert!(queue!(stdout(), Output("hi"),).is_ok());
-    assert!(queue!(stdout(), Output("hi")).is_ok());
-}
-
 /// Execute one or more command(s)
 ///
 /// # Parameters
@@ -209,3 +201,23 @@ macro_rules! impl_from {
         }
     };
 }
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn test_queue() {
+        use crate::utils::command::Output;
+        use std::io::{stdout, Write};
+        assert!(queue!(stdout(), Output("hi"),).is_ok());
+        assert!(queue!(stdout(), Output("hi")).is_ok());
+    }
+
+    #[test]
+    fn test_execute() {
+        use crate::utils::command::Output;
+        use std::io::{stdout, Write};
+        assert!(execute!(stdout(), Output("hi"),).is_ok());
+        assert!(execute!(stdout(), Output("hi")).is_ok());
+    }
+}
+

--- a/src/utils/macros.rs
+++ b/src/utils/macros.rs
@@ -203,20 +203,33 @@ macro_rules! impl_from {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
+    use crate::utils::{command::Command, error::ErrorKind};
+    use std::io::{stdout, Write};
+    pub struct FakeCommand;
+
+    impl Command for FakeCommand {
+        type AnsiType = &'static str;
+
+        fn ansi_code(&self) -> Self::AnsiType {
+            ""
+        }
+
+        #[cfg(windows)]
+        fn execute_winapi(&self) -> Result<(), ErrorKind> {
+            Ok(())
+        }
+    }
+
     #[test]
     fn test_queue() {
-        use crate::utils::command::Output;
-        use std::io::{stdout, Write};
-        assert!(queue!(stdout(), Output("hi"),).is_ok());
-        assert!(queue!(stdout(), Output("hi")).is_ok());
+        assert!(queue!(stdout(), FakeCommand,).is_ok());
+        assert!(queue!(stdout(), FakeCommand).is_ok());
     }
 
     #[test]
     fn test_execute() {
-        use crate::utils::command::Output;
-        use std::io::{stdout, Write};
-        assert!(execute!(stdout(), Output("hi"),).is_ok());
-        assert!(execute!(stdout(), Output("hi")).is_ok());
+        assert!(execute!(stdout(), FakeCommand,).is_ok());
+        assert!(execute!(stdout(), FakeCommand).is_ok());
     }
 }


### PR DESCRIPTION
All of the other Rust macros allow trailing commas, so the fact that crossterm's wouldn't let me have an extra useless comma at the end was bothering me. It really does make it much easier to work with when you have a lot of things being passed to the macro where each are on their own line.