### PR TITLE
Fix the `def_str_attr!` macro

### DIFF
--- a/src/style/macros.rs
+++ b/src/style/macros.rs
@@ -35,10 +35,13 @@ macro_rules! def_str_color {
 }
 
 macro_rules! def_str_attr {
-    ($name:ident => $color:path) => {
+    ($name:ident => $attr:path) => {
         fn $name(self) -> StyledContent<&'static str> {
             StyledContent::new(
-                Default::default(),
+                ContentStyle {
+                    attributes: vec![ $attr ],
+                    ..Default::default()
+                },
                 self
             )
         }


### PR DESCRIPTION
The `def_str_attr!` macro as it is used in src/style.rs for the implementation of `Styler` in `str` was incorrect and did practically nothing.

This broke the doc examples in `crossterm::style::Styler`.