### PR TITLE
Make use of cancellation token when polling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ version = "0.3.8"
 features = ["winuser"]
 
 [target.'cfg(windows)'.dependencies]
-crossterm_winapi = "0.5.0"
+crossterm_winapi = { version = "0.5.0", git = "https://github.com/udoprog/crossterm-winapi", branch = "shared-semaphore" }
 
 #
 # UNIX dependencies

--- a/examples/event-stream-async-std.rs
+++ b/examples/event-stream-async-std.rs
@@ -22,8 +22,8 @@ const HELP: &str = r#"EventStream based on futures::Stream with async-std
  - Use Esc to quit
 "#;
 
-async fn print_events() {
-    let mut reader = EventStream::new();
+async fn print_events() -> Result<()> {
+    let mut reader = EventStream::new()?;
 
     loop {
         let mut delay = Delay::new(Duration::from_millis(1_000)).fuse();
@@ -50,6 +50,8 @@ async fn print_events() {
             }
         };
     }
+
+    Ok(())
 }
 
 fn main() -> Result<()> {
@@ -60,7 +62,7 @@ fn main() -> Result<()> {
     let mut stdout = stdout();
     execute!(stdout, EnableMouseCapture)?;
 
-    async_std::task::block_on(print_events());
+    async_std::task::block_on(print_events())?;
 
     execute!(stdout, DisableMouseCapture)?;
     Ok(())

--- a/examples/event-stream-tokio.rs
+++ b/examples/event-stream-tokio.rs
@@ -22,8 +22,8 @@ const HELP: &str = r#"EventStream based on futures::Stream with tokio
  - Use Esc to quit
 "#;
 
-async fn print_events() {
-    let mut reader = EventStream::new();
+async fn print_events() -> Result<()> {
+    let mut reader = EventStream::new()?;
 
     loop {
         let mut delay = Delay::new(Duration::from_millis(1_000)).fuse();
@@ -50,6 +50,8 @@ async fn print_events() {
             }
         };
     }
+
+    Ok(())
 }
 
 #[tokio::main]
@@ -61,7 +63,7 @@ async fn main() -> Result<()> {
     let mut stdout = stdout();
     execute!(stdout, EnableMouseCapture)?;
 
-    print_events().await;
+    print_events().await?;
 
     execute!(stdout, DisableMouseCapture)?;
     Ok(())

--- a/src/cursor/sys/unix.rs
+++ b/src/cursor/sys/unix.rs
@@ -36,7 +36,11 @@ fn read_position_raw() -> Result<(u16, u16)> {
     stdout.flush()?;
 
     loop {
-        match poll_internal(Some(Duration::from_millis(2000)), &CursorPositionFilter) {
+        match poll_internal(
+            Some(Duration::from_millis(2000)),
+            &CursorPositionFilter,
+            None,
+        ) {
             Ok(true) => {
                 if let Ok(InternalEvent::CursorPosition(x, y)) =
                     read_internal(&CursorPositionFilter)

--- a/src/event/source.rs
+++ b/src/event/source.rs
@@ -6,6 +6,10 @@ use super::InternalEvent;
 pub mod unix;
 #[cfg(windows)]
 pub mod windows;
+#[cfg(unix)]
+pub use crate::event::sys::unix::{cancellation, CancelRx, CancelTx};
+#[cfg(windows)]
+pub use crate::event::sys::windows::{cancellation, CancelRx, CancelTx};
 
 /// An interface for trying to read an `InternalEvent` within an optional `Duration`.
 pub(crate) trait EventSource: Sync + Send {
@@ -18,8 +22,9 @@ pub(crate) trait EventSource: Sync + Send {
     /// Returns:
     /// `Ok(Some(event))`: in case an event is ready.
     /// `Ok(None)`: in case an event is not ready.
-    fn try_read(&mut self, timeout: Option<Duration>) -> crate::Result<Option<InternalEvent>>;
-
-    /// Forces the `try_read` method to return `Ok(None)` immediately.
-    fn wake(&self);
+    fn try_read(
+        &mut self,
+        timeout: Option<Duration>,
+        cancel: Option<&CancelRx>,
+    ) -> crate::Result<Option<InternalEvent>>;
 }


### PR DESCRIPTION
This is just to showcase the API I'm proposing to solve the apparent deadlock in EventStream. I've only implemented it for Windows for now, but the same concept should be possible on unix as well.

This api will allow other threads to cancel a read, which is necessary to properly clean up resources for certain operations.

If it looks good, I can build the unix impl as well.

Needs crossterm-rs/crossterm-winapi#9 before it can be merged.