### PR TITLE
Fix xterm mouse parser

### DIFF
--- a/src/event/sys/unix.rs
+++ b/src/event/sys/unix.rs
@@ -498,7 +498,7 @@ pub(crate) fn parse_csi_xterm_mouse(buffer: &[u8]) -> Result<Option<InternalEven
 
         let drag = cb & 0b0010_0000 == 0b0010_0000;
 
-        match (cb & 0b111, up, drag) {
+        match (cb & 0b0000_0011, up, drag) {
             (0, true, _) => MouseEvent::Up(MouseButton::Left, cx, cy, modifiers),
             (0, false, false) => MouseEvent::Down(MouseButton::Left, cx, cy, modifiers),
             (0, false, true) => MouseEvent::Drag(MouseButton::Left, cx, cy, modifiers),


### PR DESCRIPTION
Only two bits represents button state, not three. Prior this change, when SHIFT is pressed, `None` is returned because `cb & 0b111` becomes `4` -> `could_not_parse_event_error`.

Signed-off-by: Robert Vojta <rvojta@me.com>