### PR TITLE
EventStream::drop dead lock fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ event-stream = ["futures"]
 #
 [dependencies]
 bitflags = "1.2"
-cfg-if = "0.1"
 futures = { version = "0.3", optional = true }
 lazy_static = "1.4"
 parking_lot = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ event-stream = ["futures"]
 #
 [dependencies]
 bitflags = "1.2"
+cfg-if = "0.1"
 futures = { version = "0.3", optional = true }
 lazy_static = "1.4"
 parking_lot = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ version = "0.3.8"
 features = ["winuser"]
 
 [target.'cfg(windows)'.dependencies]
-crossterm_winapi = "0.5.0"
+crossterm_winapi = "0.5.1"
 
 #
 # UNIX dependencies

--- a/examples/event-poll-read.rs
+++ b/examples/event-poll-read.rs
@@ -49,7 +49,7 @@ fn print_events() -> Result<()> {
 fn main() -> Result<()> {
     println!("{}", HELP);
 
-    enable_raw_mode();
+    enable_raw_mode()?;
 
     let mut stdout = stdout();
     execute!(stdout, EnableMouseCapture)?;

--- a/src/event/read.rs
+++ b/src/event/read.rs
@@ -35,11 +35,8 @@ impl Default for InternalEventReader {
 
 impl InternalEventReader {
     #[cfg(feature = "event-stream")]
-    pub(crate) fn poll_waker(&self) -> Waker {
-        self.source
-            .as_ref()
-            .expect("reader source not set")
-            .try_read_waker()
+    pub(crate) fn waker(&self) -> Waker {
+        self.source.as_ref().expect("reader source not set").waker()
     }
 
     pub(crate) fn poll<F>(&mut self, timeout: Option<Duration>, filter: &F) -> Result<bool>
@@ -447,7 +444,7 @@ mod tests {
         }
 
         #[cfg(feature = "event-stream")]
-        fn try_read_waker(&self) -> super::super::sys::Waker {
+        fn waker(&self) -> super::super::sys::Waker {
             unimplemented!();
         }
     }

--- a/src/event/read.rs
+++ b/src/event/read.rs
@@ -446,6 +446,9 @@ mod tests {
             Ok(None)
         }
 
-        fn wake(&self) {}
+        #[cfg(feature = "event-stream")]
+        fn try_read_waker(&self) -> super::super::sys::Waker {
+            unimplemented!();
+        }
     }
 }

--- a/src/event/read.rs
+++ b/src/event/read.rs
@@ -34,6 +34,7 @@ impl Default for InternalEventReader {
 }
 
 impl InternalEventReader {
+    /// Returns a `Waker` allowing to wake/force the `poll` method to return `Ok(false)`.
     #[cfg(feature = "event-stream")]
     pub(crate) fn waker(&self) -> Waker {
         self.source.as_ref().expect("reader source not set").waker()

--- a/src/event/source.rs
+++ b/src/event/source.rs
@@ -2,20 +2,13 @@ use std::time::Duration;
 
 use super::InternalEvent;
 
-cfg_if::cfg_if! {
-    if #[cfg(unix)] {
-        pub(crate) mod unix;
-    } else if #[cfg(windows)] {
-        pub(crate) mod windows;
-    }
-}
+#[cfg(feature = "event-stream")]
+use super::sys::Waker;
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "event-stream")] {
-        use std::sync::Arc;
-        use super::sys::Waker;
-    }
-}
+#[cfg(unix)]
+pub(crate) mod unix;
+#[cfg(windows)]
+pub(crate) mod windows;
 
 /// An interface for trying to read an `InternalEvent` within an optional `Duration`.
 pub(crate) trait EventSource: Sync + Send {
@@ -31,5 +24,5 @@ pub(crate) trait EventSource: Sync + Send {
     fn try_read(&mut self, timeout: Option<Duration>) -> crate::Result<Option<InternalEvent>>;
 
     #[cfg(feature = "event-stream")]
-    fn waker(&self) -> Arc<Waker>;
+    fn try_read_waker(&self) -> Waker;
 }

--- a/src/event/source.rs
+++ b/src/event/source.rs
@@ -14,15 +14,15 @@ pub(crate) mod windows;
 pub(crate) trait EventSource: Sync + Send {
     /// Tries to read an `InternalEvent` within the given duration.
     ///
-    /// This function takes in an optional duration.
-    /// * `None`: blocks indefinitely until an event is able to be read.
-    /// * `Some(duration)`: blocks for the given duration.
+    /// # Arguments
     ///
-    /// Returns:
-    /// `Ok(Some(event))`: in case an event is ready.
-    /// `Ok(None)`: in case an event is not ready.
+    /// * `timeout` - `None` block indefinitely until an event is available, `Some(duration)` blocks
+    ///               for the given timeout
+    ///
+    /// Returns `Ok(None)` if there's no event available and timeout expires.
     fn try_read(&mut self, timeout: Option<Duration>) -> crate::Result<Option<InternalEvent>>;
 
+    /// Returns a `Waker` allowing to wake/force the `try_read` method to return `Ok(None)`.
     #[cfg(feature = "event-stream")]
     fn waker(&self) -> Waker;
 }

--- a/src/event/source.rs
+++ b/src/event/source.rs
@@ -24,5 +24,5 @@ pub(crate) trait EventSource: Sync + Send {
     fn try_read(&mut self, timeout: Option<Duration>) -> crate::Result<Option<InternalEvent>>;
 
     #[cfg(feature = "event-stream")]
-    fn try_read_waker(&self) -> Waker;
+    fn waker(&self) -> Waker;
 }

--- a/src/event/source.rs
+++ b/src/event/source.rs
@@ -1,9 +1,8 @@
 use std::time::Duration;
 
-use super::InternalEvent;
-
 #[cfg(feature = "event-stream")]
 use super::sys::Waker;
+use super::InternalEvent;
 
 #[cfg(unix)]
 pub(crate) mod unix;

--- a/src/event/source/unix.rs
+++ b/src/event/source/unix.rs
@@ -69,12 +69,10 @@ impl UnixInternalEventSource {
         let signals = Signals::new(&[signal_hook::SIGWINCH])?;
         poll.register(&signals, SIGNAL_TOKEN, Ready::readable(), PollOpt::level())?;
 
-        cfg_if::cfg_if! {
-            if #[cfg(feature = "event-stream")] {
-                let waker = Waker::new()?;
-                poll.register(&waker, WAKE_TOKEN, Ready::readable(), PollOpt::level())?;
-            }
-        }
+        #[cfg(feature = "event-stream")]
+        let waker = Waker::new()?;
+        #[cfg(feature = "event-stream")]
+        poll.register(&waker, WAKE_TOKEN, Ready::readable(), PollOpt::level())?;
 
         Ok(UnixInternalEventSource {
             poll,

--- a/src/event/source/unix.rs
+++ b/src/event/source/unix.rs
@@ -164,7 +164,7 @@ impl EventSource for UnixInternalEventSource {
     }
 
     #[cfg(feature = "event-stream")]
-    fn try_read_waker(&self) -> Waker {
+    fn waker(&self) -> Waker {
         self.waker.clone()
     }
 }

--- a/src/event/source/windows.rs
+++ b/src/event/source/windows.rs
@@ -11,12 +11,8 @@ use super::super::{
     InternalEvent, Result,
 };
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "event-stream")] {
-        use std::sync::Arc;
-        use super::super::sys::Waker;
-    }
-}
+#[cfg(feature = "event-stream")]
+use super::super::sys::Waker;
 
 pub(crate) struct WindowsEventSource {
     console: Console,
@@ -72,8 +68,7 @@ impl EventSource for WindowsEventSource {
     }
 
     #[cfg(feature = "event-stream")]
-    fn waker(&self) -> Arc<Waker> {
-        // TODO
-        Arc::new(Waker::new())
+    fn try_read_waker(&self) -> Waker {
+        self.poll.poll_waker()
     }
 }

--- a/src/event/source/windows.rs
+++ b/src/event/source/windows.rs
@@ -68,7 +68,7 @@ impl EventSource for WindowsEventSource {
     }
 
     #[cfg(feature = "event-stream")]
-    fn try_read_waker(&self) -> Waker {
-        self.poll.poll_waker()
+    fn waker(&self) -> Waker {
+        self.poll.waker()
     }
 }

--- a/src/event/source/windows.rs
+++ b/src/event/source/windows.rs
@@ -11,6 +11,13 @@ use super::super::{
     InternalEvent, Result,
 };
 
+cfg_if::cfg_if! {
+    if #[cfg(feature = "event-stream")] {
+        use std::sync::Arc;
+        use super::super::sys::Waker;
+    }
+}
+
 pub(crate) struct WindowsEventSource {
     console: Console,
     poll: WinApiPoll,
@@ -64,7 +71,9 @@ impl EventSource for WindowsEventSource {
         }
     }
 
-    fn wake(&self) {
-        let _ = self.poll.cancel();
+    #[cfg(feature = "event-stream")]
+    fn waker(&self) -> Arc<Waker> {
+        // TODO
+        Arc::new(Waker::new())
     }
 }

--- a/src/event/source/windows.rs
+++ b/src/event/source/windows.rs
@@ -4,15 +4,14 @@ use crossterm_winapi::{Console, Handle, InputEventType, KeyEventRecord, MouseEve
 
 use crate::event::{sys::windows::WinApiPoll, Event};
 
+#[cfg(feature = "event-stream")]
+use super::super::sys::Waker;
 use super::super::{
     source::EventSource,
     sys::windows::{handle_key_event, handle_mouse_event},
     timeout::PollTimeout,
     InternalEvent, Result,
 };
-
-#[cfg(feature = "event-stream")]
-use super::super::sys::Waker;
 
 pub(crate) struct WindowsEventSource {
     console: Console,

--- a/src/event/stream.rs
+++ b/src/event/stream.rs
@@ -13,12 +13,11 @@ use futures::{
     Stream,
 };
 
-use super::sys::Waker;
-
 use crate::Result;
 
 use super::{
-    filter::EventFilter, poll_internal, read_internal, Event, InternalEvent, INTERNAL_EVENT_READER,
+    filter::EventFilter, poll_internal, read_internal, sys::Waker, Event, InternalEvent,
+    INTERNAL_EVENT_READER,
 };
 
 /// A stream of `Result<Event>`.

--- a/src/event/stream.rs
+++ b/src/event/stream.rs
@@ -33,7 +33,7 @@ use super::{
 /// Check the [examples](https://github.com/crossterm-rs/crossterm/tree/master/examples) folder to see how to use
 /// it (`event-stream-*`).
 pub struct EventStream {
-    poll_internal_waker: Arc<Waker>,
+    poll_internal_waker: Waker,
     stream_wake_thread_spawned: Arc<AtomicBool>,
     stream_wake_thread_should_shutdown: Arc<AtomicBool>,
 }
@@ -41,7 +41,7 @@ pub struct EventStream {
 impl Default for EventStream {
     fn default() -> Self {
         EventStream {
-            poll_internal_waker: INTERNAL_EVENT_READER.write().waker(),
+            poll_internal_waker: INTERNAL_EVENT_READER.write().poll_waker(),
             stream_wake_thread_spawned: Arc::new(AtomicBool::new(false)),
             stream_wake_thread_should_shutdown: Arc::new(AtomicBool::new(false)),
         }

--- a/src/event/stream.rs
+++ b/src/event/stream.rs
@@ -41,7 +41,7 @@ pub struct EventStream {
 impl Default for EventStream {
     fn default() -> Self {
         EventStream {
-            poll_internal_waker: INTERNAL_EVENT_READER.write().poll_waker(),
+            poll_internal_waker: INTERNAL_EVENT_READER.write().waker(),
             stream_wake_thread_spawned: Arc::new(AtomicBool::new(false)),
             stream_wake_thread_should_shutdown: Arc::new(AtomicBool::new(false)),
         }

--- a/src/event/stream.rs
+++ b/src/event/stream.rs
@@ -55,6 +55,24 @@ impl EventStream {
     }
 }
 
+// Note to future me
+//
+// We need two wakers in order to implement EventStream correctly.
+//
+// 1. futures::Stream waker
+//
+// Stream::poll_next can return Poll::Pending which means that there's no
+// event available. We are going to spawn a thread with the
+// poll_internal(None, &EventFilter) call. This call blocks until an
+// event is available and then we have to wake up the executor with notification
+// that the task can be resumed.
+//
+// 2. poll_internal waker
+//
+// There's no event available, Poll::Pending was returned, stream waker thread
+// is up and sitting in the poll_internal. User wants to drop the EventStream.
+// We have to wake up the poll_internal (force it to return Ok(false)) and quit
+// the thread before we drop.
 impl Stream for EventStream {
     type Item = Result<Event>;
 

--- a/src/event/sys.rs
+++ b/src/event/sys.rs
@@ -1,8 +1,7 @@
-#[cfg(all(windows, feature = "event-stream"))]
-pub(crate) use windows::Waker;
-
 #[cfg(all(unix, feature = "event-stream"))]
 pub(crate) use unix::Waker;
+#[cfg(all(windows, feature = "event-stream"))]
+pub(crate) use windows::Waker;
 
 #[cfg(unix)]
 pub(crate) mod unix;

--- a/src/event/sys.rs
+++ b/src/event/sys.rs
@@ -1,11 +1,10 @@
-cfg_if::cfg_if! {
-    if #[cfg(unix)] {
-        pub(crate) mod unix;
-        #[cfg(feature = "event-stream")]
-        pub(crate) use unix::Waker;
-    } else if #[cfg(windows)] {
-        pub(crate) mod windows;
-        #[cfg(feature = "event-stream")]
-        pub(crate) use windows::Waker;
-    }
-}
+#[cfg(all(windows, feature = "event-stream"))]
+pub(crate) use windows::Waker;
+
+#[cfg(all(unix, feature = "event-stream"))]
+pub(crate) use unix::Waker;
+
+#[cfg(unix)]
+pub(crate) mod unix;
+#[cfg(windows)]
+pub(crate) mod windows;

--- a/src/event/sys.rs
+++ b/src/event/sys.rs
@@ -1,4 +1,11 @@
-#[cfg(unix)]
-pub mod unix;
-#[cfg(windows)]
-pub mod windows;
+cfg_if::cfg_if! {
+    if #[cfg(unix)] {
+        pub(crate) mod unix;
+        #[cfg(feature = "event-stream")]
+        pub(crate) use unix::Waker;
+    } else if #[cfg(windows)] {
+        pub(crate) mod windows;
+        #[cfg(feature = "event-stream")]
+        pub(crate) use windows::Waker;
+    }
+}

--- a/src/event/sys/unix.rs
+++ b/src/event/sys/unix.rs
@@ -12,12 +12,11 @@ use crate::{
 
 use super::super::InternalEvent;
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "event-stream")] {
-        pub(crate) use waker::Waker;
-        mod waker;
-    }
-}
+#[cfg(feature = "event-stream")]
+pub(crate) use waker::Waker;
+
+#[cfg(feature = "event-stream")]
+mod waker;
 
 /// A file descriptor wrapper.
 ///

--- a/src/event/sys/unix.rs
+++ b/src/event/sys/unix.rs
@@ -5,15 +5,15 @@ use std::{
 
 use libc::size_t;
 
+#[cfg(feature = "event-stream")]
+pub(crate) use waker::Waker;
+
 use crate::{
     event::{Event, KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent},
     ErrorKind, Result,
 };
 
 use super::super::InternalEvent;
-
-#[cfg(feature = "event-stream")]
-pub(crate) use waker::Waker;
 
 #[cfg(feature = "event-stream")]
 mod waker;

--- a/src/event/sys/unix.rs
+++ b/src/event/sys/unix.rs
@@ -3,7 +3,7 @@ use std::{
     os::unix::io::{IntoRawFd, RawFd},
 };
 
-use libc::{c_int, c_void, size_t, ssize_t};
+use libc::size_t;
 
 use crate::{
     event::{Event, KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent},
@@ -12,20 +12,10 @@ use crate::{
 
 use super::super::InternalEvent;
 
-// libstd::sys::unix::fd.rs
-fn max_len() -> usize {
-    // The maximum read limit on most posix-like systems is `SSIZE_MAX`,
-    // with the man page quoting that if the count of bytes to read is
-    // greater than `SSIZE_MAX` the result is "unspecified".
-    //
-    // On macOS, however, apparently the 64-bit libc is either buggy or
-    // intentionally showing odd behavior by rejecting any read with a size
-    // larger than or equal to INT_MAX. To handle both of these the read
-    // size is capped on both platforms.
-    if cfg!(target_os = "macos") {
-        <c_int>::max_value() as usize - 1
-    } else {
-        <ssize_t>::max_value() as usize
+cfg_if::cfg_if! {
+    if #[cfg(feature = "event-stream")] {
+        pub(crate) use waker::Waker;
+        mod waker;
     }
 }
 
@@ -63,24 +53,6 @@ impl FileDesc {
         } else {
             Ok(result as usize)
         }
-    }
-
-    pub fn write(&self, buf: &[u8]) -> io::Result<usize> {
-        // libstd::sys::unix::fd.rs
-
-        let ret = unsafe {
-            libc::write(
-                self.fd,
-                buf.as_ptr() as *const c_void,
-                std::cmp::min(buf.len(), max_len()) as size_t,
-            ) as c_int
-        };
-
-        if ret == -1 {
-            return Err(io::Error::last_os_error());
-        }
-
-        Ok(ret as usize)
     }
 
     /// Returns the underlying file descriptor.

--- a/src/event/sys/unix/waker.rs
+++ b/src/event/sys/unix/waker.rs
@@ -1,3 +1,5 @@
+// TODO Replace with `mio::Waker` when the 0.7 is released (not available in 0.6).
+
 use std::sync::{Arc, Mutex};
 
 use mio::{Evented, Poll, PollOpt, Ready, Registration, SetReadiness, Token};
@@ -30,22 +32,33 @@ impl WakerInner {
     }
 }
 
+/// Allows to wake up the `mio::Poll::poll()` method.
 #[derive(Clone)]
 pub(crate) struct Waker {
     inner: Arc<Mutex<WakerInner>>,
 }
 
 impl Waker {
+    /// Creates a new waker.
+    ///
+    /// `Waker` implements the `mio::Evented` trait and you have to register
+    /// it in order to use it.
     pub(crate) fn new() -> Result<Self> {
         Ok(Self {
             inner: Arc::new(Mutex::new(WakerInner::new())),
         })
     }
 
+    /// Wakes the `mio::Poll.poll()` method.
+    ///
+    /// Readiness is set to `Ready::readable()`.
     pub(crate) fn wake(&self) -> Result<()> {
         self.inner.lock().unwrap().wake()
     }
 
+    /// Resets the state so the same waker can be reused.
+    ///
+    /// Readiness is set back to `Ready::empty()`.
     pub(crate) fn reset(&self) -> Result<()> {
         self.inner.lock().unwrap().reset()
     }

--- a/src/event/sys/unix/waker.rs
+++ b/src/event/sys/unix/waker.rs
@@ -1,0 +1,55 @@
+use std::io;
+
+use mio::{Evented, Poll, PollOpt, Ready, Registration, SetReadiness, Token};
+
+#[derive(Debug)]
+pub(crate) struct Waker {
+    registration: Registration,
+    set_readiness: SetReadiness,
+}
+
+impl Waker {
+    pub(crate) fn new() -> Self {
+        let (registration, set_readiness) = Registration::new2();
+
+        Waker {
+            registration,
+            set_readiness,
+        }
+    }
+
+    pub(crate) fn wake(&self) -> io::Result<()> {
+        self.set_readiness.set_readiness(Ready::readable())
+    }
+
+    pub(crate) fn clear(&self) -> io::Result<()> {
+        self.set_readiness.set_readiness(Ready::empty())
+    }
+}
+
+impl Evented for Waker {
+    fn register(
+        &self,
+        poll: &Poll,
+        token: Token,
+        interest: Ready,
+        opts: PollOpt,
+    ) -> io::Result<()> {
+        self.registration.register(poll, token, interest, opts)
+    }
+
+    fn reregister(
+        &self,
+        poll: &Poll,
+        token: Token,
+        interest: Ready,
+        opts: PollOpt,
+    ) -> io::Result<()> {
+        self.registration.reregister(poll, token, interest, opts)
+    }
+
+    #[allow(deprecated)]
+    fn deregister(&self, poll: &Poll) -> io::Result<()> {
+        self.registration.deregister(poll)
+    }
+}

--- a/src/event/sys/windows.rs
+++ b/src/event/sys/windows.rs
@@ -273,14 +273,13 @@ impl WinApiPoll {
 
         let console_handle = Handle::current_in_handle()?;
 
-        cfg_if::cfg_if! {
-            if #[cfg(feature = "event-stream")] {
-                let semaphore = self.waker.semaphore();
-                let handles = &[*console_handle, **semaphore.handle()];
-            } else {
-                let handles = &[*console_handle];
-            }
-        }
+        #[cfg(feature = "event-stream")]
+        let semaphore = self.waker.semaphore();
+        #[cfg(feature = "event-stream")]
+        let handles = &[*console_handle, **semaphore.handle()];
+        #[cfg(not(feature = "event-stream"))]
+        let handles = &[*console_handle];
+
         let output =
             unsafe { WaitForMultipleObjects(handles.len() as u32, handles.as_ptr(), 0, dw_millis) };
 

--- a/src/event/sys/windows.rs
+++ b/src/event/sys/windows.rs
@@ -29,6 +29,13 @@ use crate::{
     Result,
 };
 
+cfg_if::cfg_if! {
+    if #[cfg(feature = "event-stream")] {
+        pub(crate) use waker::Waker;
+        mod waker;
+    }
+}
+
 const ENABLE_MOUSE_MODE: u32 = 0x0010 | 0x0080 | 0x0008;
 
 lazy_static! {
@@ -260,7 +267,7 @@ impl WinApiPoll {
 
         let semaphore = Semaphore::new()?;
         let console_handle = Handle::current_in_handle()?;
-        let handles = &[*console_handle, semaphore.handle()];
+        let handles = &[*console_handle]; //, semaphore.handle()];
 
         self.semaphore = Some(semaphore);
 

--- a/src/event/sys/windows.rs
+++ b/src/event/sys/windows.rs
@@ -27,13 +27,11 @@ use crate::{
     event::{Event, KeyCode, KeyEvent, KeyModifiers, MouseButton},
     Result,
 };
+#[cfg(feature = "event-stream")]
+pub(crate) use waker::Waker;
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "event-stream")] {
-        pub(crate) use waker::Waker;
-        mod waker;
-    }
-}
+#[cfg(feature = "event-stream")]
+mod waker;
 
 const ENABLE_MOUSE_MODE: u32 = 0x0010 | 0x0080 | 0x0008;
 
@@ -252,15 +250,16 @@ pub(crate) struct WinApiPoll {
 }
 
 impl WinApiPoll {
+    #[cfg(not(feature = "event-stream"))]
     pub(crate) fn new() -> Result<WinApiPoll> {
-        cfg_if::cfg_if! {
-            if #[cfg(feature = "event-stream")] {
-                let waker = Waker::new()?;
-                Ok(WinApiPoll { waker })
-            } else {
-                Ok(WinApiPoll {})
-            }
-        }
+        Ok(WinApiPoll {})
+    }
+
+    #[cfg(feature = "event-stream")]
+    pub(crate) fn new() -> Result<WinApiPoll> {
+        Ok(WinApiPoll {
+            waker: Waker::new()?,
+        })
     }
 }
 

--- a/src/event/sys/windows.rs
+++ b/src/event/sys/windows.rs
@@ -308,7 +308,7 @@ impl WinApiPoll {
     }
 
     #[cfg(feature = "event-stream")]
-    pub fn poll_waker(&self) -> Waker {
+    pub fn waker(&self) -> Waker {
         self.waker.clone()
     }
 }

--- a/src/event/sys/windows/waker.rs
+++ b/src/event/sys/windows/waker.rs
@@ -4,12 +4,17 @@ use crossterm_winapi::Semaphore;
 
 use crate::Result;
 
+/// Allows to wake up the `WinApiPoll::poll()` method.
 #[derive(Clone)]
 pub(crate) struct Waker {
     inner: Arc<Mutex<Semaphore>>,
 }
 
 impl Waker {
+    /// Creates a new waker.
+    ///
+    /// `Waker` is based on the `Semaphore`. You have to use the semaphore
+    /// handle along with the `WaitForMultipleObjects`.
     pub(crate) fn new() -> Result<Self> {
         let inner = Semaphore::new()?;
 
@@ -18,16 +23,19 @@ impl Waker {
         })
     }
 
+    /// Wakes the `WaitForMultipleObjects`.
     pub(crate) fn wake(&self) -> Result<()> {
         self.inner.lock().unwrap().release()?;
         Ok(())
     }
 
+    /// Replaces the current semaphore with a new one allowing us to reuse the same `Waker`.
     pub(crate) fn reset(&self) -> Result<()> {
         *self.inner.lock().unwrap() = Semaphore::new()?;
         Ok(())
     }
 
+    /// Returns the semaphore associated with the waker.
     pub(crate) fn semaphore(&self) -> Semaphore {
         self.inner.lock().unwrap().clone()
     }

--- a/src/event/sys/windows/waker.rs
+++ b/src/event/sys/windows/waker.rs
@@ -1,0 +1,17 @@
+use std::io;
+
+pub(crate) struct Waker;
+
+impl Waker {
+    pub(crate) fn new() -> Self {
+        Waker {}
+    }
+
+    pub(crate) fn wake(&self) -> io::Result<()> {
+        Ok(())
+    }
+
+    pub(crate) fn clear(&self) -> io::Result<()> {
+        Ok(())
+    }
+}

--- a/src/utils/functions.rs
+++ b/src/utils/functions.rs
@@ -1,5 +1,6 @@
-use super::sys::windows::set_virtual_terminal_processing;
 use lazy_static::lazy_static;
+
+use super::sys::windows::set_virtual_terminal_processing;
 
 lazy_static! {
     static ref SUPPORTS_ANSI_ESCAPE_CODES: bool = {


### PR DESCRIPTION
## Description

* There was a dead lock in the `EventStream::drop` implementation (thanks for the discovery @udoprog!)

## Changes

* Introduced `Waker` which kind of mimicks upcoming `mio` (0.7) `Waker`
  * Allows us to remove self pipe trick, etc. and do it via `Evented` on UNIX
  * `Waker` is clonable, shareable, sendable, ...
* Implemented for both Windows & UNIX

## Tests

* Tested on **UNIX only**

## Alternative

This is an alternative to the #328 PR.

What's better?

* No public reexports of `CancelRx`, ...
* No warnings for unused imports, dead code, ...
* Completely hidden and not visible in the internal API until `event-stream` is enabled

What's worse?

* Not sure if it's a good idea to hide it in this way = removing it from the `poll_internal` argument