### PR TITLE
README: Update Getting started example for 0.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ crossterm = "0.14"
 ```rust
 use std::io::{stdout, Write};
 
-use crossterm::{execute, ExecutableCommand, style::{Attribute, Color, SetForegroundColor, SetBackgroundColor, ResetColor, Print}, Result};
+use crossterm::{execute, ExecutableCommand, style::{Color, SetForegroundColor, SetBackgroundColor, ResetColor, Print}, Result};
 
 fn main() -> Result<()> {
     // using the macro

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ fn main() -> Result<()> {
         stdout(),
         SetForegroundColor(Color::Blue),
         SetBackgroundColor(Color::Red),
-        Output("Styled text here."),
+        Print("Styled text here."),
         ResetColor
     )?;
 
@@ -133,7 +133,7 @@ fn main() -> Result<()> {
     stdout()
         .execute(SetForegroundColor(Color::Blue))?
         .execute(SetBackgroundColor(Color::Red))?
-        .execute(Output("Styled text here."))?
+        .execute(Print("Styled text here."))?
         .execute(ResetColor)?;
 
     Ok(())

--- a/README.md
+++ b/README.md
@@ -117,7 +117,11 @@ crossterm = "0.14"
 ```rust
 use std::io::{stdout, Write};
 
-use crossterm::{execute, ExecutableCommand, style::{Color, SetForegroundColor, SetBackgroundColor, ResetColor, Print}, Result};
+use crossterm::{
+    execute,
+    style::{Color, Print, ResetColor, SetBackgroundColor, SetForegroundColor},
+    ExecutableCommand, Result,
+};
 
 fn main() -> Result<()> {
     // using the macro

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ fn main() -> Result<()> {
 }
 ```
 
-Checkout this [list](https://docs.rs/crossterm/0.13.0/crossterm/index.html#supported-commands) with all possible commands.
+Checkout this [list](https://docs.rs/crossterm/0.14.0/crossterm/index.html#supported-commands) with all possible commands.
 
 ### Feature Flags
 


### PR DESCRIPTION
Updated:
- Getting Started example to reflect current 0.14 api
    - Ran cargo-fmt on example
- Command list link from 0.13 to 0.14 url


Original example resulted in the following errors and warnings:
```sh
error[E0425]: cannot find function `Output` in this scope
  --> src/main.rs:11:9
   |
11 |         Output("Styled text here."),
   |         ^^^^^^ not found in this scope

error[E0425]: cannot find function `Output` in this scope
  --> src/main.rs:19:18
   |
19 |         .execute(Output("Styled text here."))?
   |                  ^^^^^^ not found in this scope

warning: unused imports: `Attribute`, `Print`
 --> src/main.rs:3:53
  |
3 | use crossterm::{execute, ExecutableCommand, style::{Attribute, Color, SetForegroundColor, SetBackgroundColor, ResetColor, Print}, Result};
  |                                                     ^^^^^^^^^                                                             ^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default
```