### PR TITLE
avoid double evaluation of expression in `handle_command!` on windows

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -32,14 +32,14 @@ macro_rules! handle_command {
 
         #[cfg(windows)]
         {
+            let command = $command;
             // ansi code is not always a string, however it does implement `Display` and `Write`.
             // In order to check if the code is supported we have to make it a string.
-            let ansi_code = format!("{}", $command.ansi_code());
-
-            if $command.is_ansi_code_supported() {
+            let ansi_code = format!("{}", command.ansi_code());
+            if command.is_ansi_code_supported() {
                 write_ansi_code!($writer, &ansi_code)
             } else {
-                $command.execute_winapi().map_err($crate::ErrorKind::from)
+                command.execute_winapi().map_err($crate::ErrorKind::from)
             }
         }
         #[cfg(unix)]


### PR DESCRIPTION
The `$command` expression was copied in place twice in
the Windows version of the macro, which added useless
(and very hard to analyze) constraints on user code.

Related: https://github.com/Canop/termimad/issues/13#issuecomment-565848039