### PR TITLE
Change `__Nonexhaustive` variants to `#[non_exhaustive]`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -11,6 +11,7 @@ use crate::impl_from;
 pub type Result<T> = std::result::Result<T, ErrorKind>;
 
 /// Wrapper for all errors that can occur in `crossterm`.
+#[non_exhaustive]
 #[derive(Debug)]
 pub enum ErrorKind {
     IoError(io::Error),
@@ -18,9 +19,6 @@ pub enum ErrorKind {
     Utf8Error(std::string::FromUtf8Error),
     ParseIntError(std::num::ParseIntError),
     ResizingTerminalFailure(String),
-
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 impl std::error::Error for ErrorKind {

--- a/src/style/enums/attribute.rs
+++ b/src/style/enums/attribute.rs
@@ -56,6 +56,7 @@ use super::super::SetAttribute;
 /// println!("{}", "Negative text".negative());
 /// ```
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[non_exhaustive]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]
 pub enum Attribute {
     /// Resets all the attributes.
@@ -108,9 +109,6 @@ pub enum Attribute {
     NotFramedOrEncircled = 54,
     /// Turns off the `OverLined` attribute.
     NotOverLined = 55,
-
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 impl Display for Attribute {


### PR DESCRIPTION
> Replaces the two occurrences of an enum variant titled
`__Nonexhaustive` with the recently stabilized `#[non_exhaustive]`
attribute.

Essentially what the commit message says. Tests passed, but this is technically a backwards-incompatible change - not that it *should* affect anyone.