### PR TITLE
Fix TIOCGWINSZ for FreeBSD

### DIFF
--- a/src/terminal/sys/unix.rs
+++ b/src/terminal/sys/unix.rs
@@ -33,7 +33,9 @@ pub(crate) fn size() -> Result<(u16, u16)> {
         ws_ypixel: 0,
     };
 
-    if let Ok(true) = wrap_with_result(unsafe { ioctl(STDOUT_FILENO, TIOCGWINSZ.into(), &mut size) }) {
+    if let Ok(true) =
+        wrap_with_result(unsafe { ioctl(STDOUT_FILENO, TIOCGWINSZ.into(), &mut size) })
+    {
         Ok((size.ws_col, size.ws_row))
     } else {
         tput_size().ok_or_else(|| std::io::Error::last_os_error().into())

--- a/src/terminal/sys/unix.rs
+++ b/src/terminal/sys/unix.rs
@@ -33,7 +33,7 @@ pub(crate) fn size() -> Result<(u16, u16)> {
         ws_ypixel: 0,
     };
 
-    if let Ok(true) = wrap_with_result(unsafe { ioctl(STDOUT_FILENO, TIOCGWINSZ, &mut size) }) {
+    if let Ok(true) = wrap_with_result(unsafe { ioctl(STDOUT_FILENO, TIOCGWINSZ.into(), &mut size) }) {
         Ok((size.ws_col, size.ws_row))
     } else {
         tput_size().ok_or_else(|| std::io::Error::last_os_error().into())


### PR DESCRIPTION
In FreeBSD, this code doesn't compile and errs with the following message:
```
  --> /home/dev/.cargo/registry/src/github.com-1ecc6299db9ec823/crossterm-0.14.1/src/terminal/sys/unix.rs:36:70
   |
36 |     if let Ok(true) = wrap_with_result(unsafe { ioctl(STDOUT_FILENO, TIOCGWINSZ, &mut size) }) {
   |                                                                      ^^^^^^^^^^
   |                                                                      |
   |                                                                      expected u64, found u32
   |                                                                      help: you can convert an `u32` to `u64`: `TIOCGWINSZ.into()`

```
Adding the `.into()` to address this issue.