### PR TITLE
Added basic trait implementations to all Commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Fixed minor syntax bug in `execute!` and `queue!`.
 - Cleaned up implementation of `execute!` and `queue!`.
 - **breaking change** Changed `ContentStyle::apply` to take self by value instead of reference, to prevent an unnecessary extra clone.
+- Added basic trait implementations (`Debug`, `Clone`, `Copy`, etc) to all of the command structs
+- `ResetColor` uses `&'static str` instead of `String`
 
 # Version 0.14.2
 - Fix TIOCGWINSZ for FreeBSD

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ version = "0.3.8"
 features = ["winuser"]
 
 [target.'cfg(windows)'.dependencies]
-crossterm_winapi = "0.5.1"
+crossterm_winapi = "0.6.0"
 
 #
 # UNIX dependencies

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -57,6 +57,7 @@ pub(crate) mod sys;
 ///
 /// * Top left cell is represented as `0,0`.
 /// * Commands must be executed/queued for execution otherwise they do nothing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MoveTo(pub u16, pub u16);
 
 impl Command for MoveTo {
@@ -78,6 +79,7 @@ impl Command for MoveTo {
 /// # Notes
 ///
 /// Commands must be executed/queued for execution otherwise they do nothing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MoveToNextLine(pub u16);
 
 impl Command for MoveToNextLine {
@@ -99,6 +101,7 @@ impl Command for MoveToNextLine {
 /// # Notes
 ///
 /// Commands must be executed/queued for execution otherwise they do nothing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MoveToPreviousLine(pub u16);
 
 impl Command for MoveToPreviousLine {
@@ -119,6 +122,7 @@ impl Command for MoveToPreviousLine {
 /// # Notes
 ///
 /// Commands must be executed/queued for execution otherwise they do nothing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MoveToColumn(pub u16);
 
 impl Command for MoveToColumn {
@@ -139,6 +143,7 @@ impl Command for MoveToColumn {
 /// # Notes
 ///
 /// Commands must be executed/queued for execution otherwise they do nothing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MoveUp(pub u16);
 
 impl Command for MoveUp {
@@ -159,6 +164,7 @@ impl Command for MoveUp {
 /// # Notes
 ///
 /// Commands must be executed/queued for execution otherwise they do nothing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MoveRight(pub u16);
 
 impl Command for MoveRight {
@@ -179,6 +185,7 @@ impl Command for MoveRight {
 /// # Notes
 ///
 /// Commands must be executed/queued for execution otherwise they do nothing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MoveDown(pub u16);
 
 impl Command for MoveDown {
@@ -199,6 +206,7 @@ impl Command for MoveDown {
 /// # Notes
 ///
 /// Commands must be executed/queued for execution otherwise they do nothing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MoveLeft(pub u16);
 
 impl Command for MoveLeft {
@@ -222,6 +230,7 @@ impl Command for MoveLeft {
 ///
 /// - The cursor position is stored globally.
 /// - Commands must be executed/queued for execution otherwise they do nothing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SavePosition;
 
 impl Command for SavePosition {
@@ -245,6 +254,7 @@ impl Command for SavePosition {
 ///
 /// - The cursor position is stored globally.
 /// - Commands must be executed/queued for execution otherwise they do nothing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RestorePosition;
 
 impl Command for RestorePosition {
@@ -265,6 +275,7 @@ impl Command for RestorePosition {
 /// # Notes
 ///
 /// - Commands must be executed/queued for execution otherwise they do nothing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Hide;
 
 impl Command for Hide {
@@ -285,6 +296,7 @@ impl Command for Hide {
 /// # Notes
 ///
 /// - Commands must be executed/queued for execution otherwise they do nothing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Show;
 
 impl Command for Show {
@@ -306,6 +318,7 @@ impl Command for Show {
 ///
 /// - Windows versions lower than Windows 10 do not support this functionality.
 /// - Commands must be executed/queued for execution otherwise they do nothing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct EnableBlinking;
 
 impl Command for EnableBlinking {
@@ -327,6 +340,7 @@ impl Command for EnableBlinking {
 ///
 /// - Windows versions lower than Windows 10 do not support this functionality.
 /// - Commands must be executed/queued for execution otherwise they do nothing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DisableBlinking;
 
 impl Command for DisableBlinking {

--- a/src/event.rs
+++ b/src/event.rs
@@ -161,7 +161,7 @@ pub fn poll(timeout: Duration) -> Result<bool> {
 ///         // Blocks until an `Event` is available
 ///         println!("{:?}", read()?);
 ///     }
-/// }   
+/// }
 /// ```
 ///
 /// Non-blocking read:
@@ -179,9 +179,9 @@ pub fn poll(timeout: Duration) -> Result<bool> {
 ///             println!("{:?}", read()?);
 ///         } else {
 ///             // Timeout expired, no `Event` is available
-///         }       
+///         }
 ///     }
-/// }   
+/// }
 /// ```
 pub fn read() -> Result<Event> {
     match read_internal(&EventFilter)? {
@@ -221,6 +221,7 @@ where
 /// A command that enables mouse event capturing.
 ///
 /// Mouse events can be captured with [read](./fn.read.html)/[poll](./fn.poll.html).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct EnableMouseCapture;
 
 impl Command for EnableMouseCapture {
@@ -244,6 +245,7 @@ impl Command for EnableMouseCapture {
 /// A command that disables mouse event capturing.
 ///
 /// Mouse events can be captured with [read](./fn.read.html)/[poll](./fn.poll.html).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DisableMouseCapture;
 
 impl Command for DisableMouseCapture {
@@ -413,7 +415,7 @@ pub enum KeyCode {
 ///
 /// Encapsulates publicly available `Event` with additional internal
 /// events that shouldn't be publicly available to the crate users.
-#[derive(Debug, PartialOrd, PartialEq, Hash, Clone)]
+#[derive(Debug, PartialOrd, PartialEq, Hash, Clone, Eq)]
 pub(crate) enum InternalEvent {
     /// An event.
     Event(Event),

--- a/src/event/filter.rs
+++ b/src/event/filter.rs
@@ -7,6 +7,7 @@ pub(crate) trait Filter: Send + Sync + 'static {
 }
 
 #[cfg(unix)]
+#[derive(Debug, Clone)]
 pub(crate) struct CursorPositionFilter;
 
 #[cfg(unix)]
@@ -20,6 +21,7 @@ impl Filter for CursorPositionFilter {
     }
 }
 
+#[derive(Debug, Clone)]
 pub(crate) struct EventFilter;
 
 impl Filter for EventFilter {
@@ -38,6 +40,7 @@ impl Filter for EventFilter {
     }
 }
 
+#[derive(Debug, Clone)]
 pub(crate) struct InternalEventFilter;
 
 impl Filter for InternalEventFilter {

--- a/src/event/source/unix.rs
+++ b/src/event/source/unix.rs
@@ -179,6 +179,7 @@ impl EventSource for UnixInternalEventSource {
 //  * mimick anes Parser interface
 //  * move the advancing, parsing, ... stuff out of the `try_read` method
 //
+#[derive(Debug)]
 struct Parser {
     buffer: Vec<u8>,
     internal_events: VecDeque<InternalEvent>,

--- a/src/event/stream.rs
+++ b/src/event/stream.rs
@@ -31,6 +31,7 @@ use super::{
 ///
 /// Check the [examples](https://github.com/crossterm-rs/crossterm/tree/master/examples) folder to see how to use
 /// it (`event-stream-*`).
+#[derive(Debug)]
 pub struct EventStream {
     poll_internal_waker: Waker,
     stream_wake_thread_spawned: Arc<AtomicBool>,

--- a/src/event/sys/unix/file_descriptor.rs
+++ b/src/event/sys/unix/file_descriptor.rs
@@ -11,6 +11,7 @@ use crate::{ErrorKind, Result};
 ///
 /// It allows to retrieve raw file descriptor, write to the file descriptor and
 /// mainly it closes the file descriptor once dropped.
+#[derive(Debug)]
 pub struct FileDesc {
     fd: RawFd,
     close_on_drop: bool,

--- a/src/event/sys/unix/waker.rs
+++ b/src/event/sys/unix/waker.rs
@@ -6,6 +6,7 @@ use mio::{Evented, Poll, PollOpt, Ready, Registration, SetReadiness, Token};
 
 use crate::Result;
 
+#[derive(Debug)]
 struct WakerInner {
     registration: Registration,
     set_readiness: SetReadiness,
@@ -33,7 +34,7 @@ impl WakerInner {
 }
 
 /// Allows to wake up the `mio::Poll::poll()` method.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) struct Waker {
     inner: Arc<Mutex<WakerInner>>,
 }

--- a/src/event/sys/windows/poll.rs
+++ b/src/event/sys/windows/poll.rs
@@ -15,6 +15,7 @@ use crate::Result;
 #[cfg(feature = "event-stream")]
 pub(crate) use super::waker::Waker;
 
+#[derive(Debug)]
 pub(crate) struct WinApiPoll {
     #[cfg(feature = "event-stream")]
     waker: Waker,

--- a/src/event/sys/windows/waker.rs
+++ b/src/event/sys/windows/waker.rs
@@ -5,7 +5,7 @@ use crossterm_winapi::Semaphore;
 use crate::Result;
 
 /// Allows to wake up the `WinApiPoll::poll()` method.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) struct Waker {
     inner: Arc<Mutex<Semaphore>>,
 }

--- a/src/event/timeout.rs
+++ b/src/event/timeout.rs
@@ -1,6 +1,7 @@
 use std::time::{Duration, Instant};
 
 /// Keeps track of the elapsed time since the moment the polling started.
+#[derive(Debug, Clone)]
 pub struct PollTimeout {
     timeout: Option<Duration>,
     start: Instant,

--- a/src/style.rs
+++ b/src/style.rs
@@ -227,6 +227,7 @@ pub fn available_color_count() -> u16 {
 /// # Notes
 ///
 /// Commands must be executed/queued for execution otherwise they do nothing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SetForegroundColor(pub Color);
 
 impl Command for SetForegroundColor {
@@ -249,6 +250,7 @@ impl Command for SetForegroundColor {
 /// # Notes
 ///
 /// Commands must be executed/queued for execution otherwise they do nothing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SetBackgroundColor(pub Color);
 
 impl Command for SetBackgroundColor {
@@ -271,6 +273,7 @@ impl Command for SetBackgroundColor {
 /// # Notes
 ///
 /// Commands must be executed/queued for execution otherwise they do nothing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SetAttribute(pub Attribute);
 
 impl Command for SetAttribute {
@@ -294,6 +297,7 @@ impl Command for SetAttribute {
 /// # Notes
 ///
 /// Commands must be executed/queued for execution otherwise they do nothing.
+#[derive(Debug, Clone)]
 pub struct PrintStyledContent<D: Display + Clone>(pub StyledContent<D>);
 
 impl<D> Command for PrintStyledContent<D>
@@ -317,13 +321,14 @@ where
 /// # Notes
 ///
 /// Commands must be executed/queued for execution otherwise they do nothing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ResetColor;
 
 impl Command for ResetColor {
-    type AnsiType = String;
+    type AnsiType = &'static str;
 
     fn ansi_code(&self) -> Self::AnsiType {
-        ansi::RESET_CSI_SEQUENCE.to_string()
+        ansi::RESET_CSI_SEQUENCE
     }
 
     #[cfg(windows)]
@@ -335,6 +340,7 @@ impl Command for ResetColor {
 /// A command that prints the given displayable type.
 ///
 /// Commands must be executed/queued for execution otherwise they do nothing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Print<T: Display + Clone>(pub T);
 
 impl<T: Display + Clone> Command for Print<T> {

--- a/src/style/styled_content.rs
+++ b/src/style/styled_content.rs
@@ -27,7 +27,7 @@ use crate::{
 ///
 /// println!("{}", styled);
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct StyledContent<D: Display> {
     /// The style (colors, content attributes).
     style: ContentStyle,

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -141,6 +141,7 @@ pub fn size() -> Result<(u16, u16)> {
 /// }
 /// ```
 ///
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct EnterAlternateScreen;
 
 impl Command for EnterAlternateScreen {
@@ -180,6 +181,7 @@ impl Command for EnterAlternateScreen {
 /// }
 /// ```
 ///
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct LeaveAlternateScreen;
 
 impl Command for LeaveAlternateScreen {
@@ -218,6 +220,7 @@ pub enum ClearType {
 /// # Notes
 ///
 /// Commands must be executed/queued for execution otherwise they do nothing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ScrollUp(pub u16);
 
 impl Command for ScrollUp {
@@ -238,6 +241,7 @@ impl Command for ScrollUp {
 /// # Notes
 ///
 /// Commands must be executed/queued for execution otherwise they do nothing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ScrollDown(pub u16);
 
 impl Command for ScrollDown {
@@ -260,6 +264,7 @@ impl Command for ScrollDown {
 /// # Notes
 ///
 /// Commands must be executed/queued for execution otherwise they do nothing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Clear(pub ClearType);
 
 impl Command for Clear {
@@ -286,6 +291,7 @@ impl Command for Clear {
 /// # Notes
 ///
 /// Commands must be executed/queued for execution otherwise they do nothing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SetSize(pub u16, pub u16);
 
 impl Command for SetSize {


### PR DESCRIPTION
Added a small set of reasonable trait implementations (`Debug`, `Copy`, `Clone`, `PartialEq`, and `Eq`) to all of the commands. The largest command is a pair of `u16`, so they're easily copyable.