### PR TITLE
Command trait ref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# master
+- Added a generic implementation `Command` for `&T: Command`. This allows
+  commands to be queued by reference, as well as by value.
+
 # Version 0.14.2
 - Fix TIOCGWINSZ for FreeBSD
 
@@ -18,14 +22,14 @@
 - Replace `docs/UPGRADE.md` with the [Upgrade Paths](https://github.com/crossterm-rs/crossterm/wiki#upgrade-paths)
   documentation
 - Add `MoveToColumn`, `MoveToPreviousLine`, `MoveToNextLine` commands
-- Merge `screen` module into `terminal`  
+- Merge `screen` module into `terminal`
     - Remove `screen::AlternateScreen`
     - Remove `screen::Rawscreen`
       * Move and rename `Rawscreen::into_raw_mode` and `Rawscreen::disable_raw_mode` to `terminal::enable_raw_mode` and `terminal::disable_raw_mode`
     - Move `screen::EnterAlternateScreen` and `screen::LeaveAlternateScreen` to `terminal::EnterAlternateScreen` and `terminal::LeaveAlternateScreen`
     - Replace `utils::Output` command with `style::Print` command
 - Fix enable/disable mouse capture commands on Windows
-- Allow trailing comma `queue!` & `execute!` macros  
+- Allow trailing comma `queue!` & `execute!` macros
 
 # Version 0.13.3
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -39,6 +39,27 @@ pub trait Command {
     }
 }
 
+impl<T: Command> Command for &T {
+    type AnsiType = T::AnsiType;
+
+    #[inline]
+    fn ansi_code(&self) -> Self::AnsiType {
+        T::ansi_code(self)
+    }
+
+    #[inline]
+    #[cfg(windows)]
+    fn execute_winapi(&self) -> Result<()> {
+        T::execute_winapi(self)
+    }
+
+    #[cfg(windows)]
+    #[inline]
+    fn is_ansi_code_supported(&self) -> bool {
+        T::is_ansi_code_supported(self)
+    }
+}
+
 /// An interface for commands that can be queued for further execution.
 pub trait QueueableCommand<T: Display>: Sized {
     /// Queues the given command for further execution.


### PR DESCRIPTION
Added an implementation of `Command` for `&T: Command`. This allows commands to be queued by reference, as well as by value:

```
fn queue_many(command: impl Command, times: usize, mut dest: impl Write) -> Result<()> {
    (0..times).try_for_each(move |_| {
        // Can't do dest.queue(command) because we can't move it
        dest.queue(&command)
    })
}
```