### PR TITLE
Cleaned up command macros and StyledContent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # master
-- Added a generic implementation `Command` for `&T: Command`. This allows
-  commands to be queued by reference, as well as by value.
+- Added a generic implementation `Command` for `&T: Command`. This allows commands to be queued by reference, as well as by value.
+- Removed unnecessary trait bounds from StyledContent.
+- Added `StyledContent::style_mut`.
+- `execute!` and `queue!` now correctly handle errors during writing.
+- Fixed minor syntax bug in `execute!` and `queue!`.
+- Cleaned up implementation of `execute!` and `queue!`.
+- **breaking change** Changed `ContentStyle::apply` to take self by value instead of reference, to prevent an unnecessary extra clone.
 
 # Version 0.14.2
 - Fix TIOCGWINSZ for FreeBSD

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -352,9 +352,9 @@ mod tests {
                 // Both are populated
                 (false, false) => panic!(
                     "Both the writer and the event stream were written to.\n\
-                    Only one should be used, based on is_ansi_code_supported.\n\
-                      stream: {stream:?}\n\
-                      writer: {writer:?}",
+                     Only one should be used, based on is_ansi_code_supported.\n\
+                     stream: {stream:?}\n\
+                     writer: {writer:?}",
                     stream = stream,
                     writer = writer,
                 ),

--- a/src/style/content_style.rs
+++ b/src/style/content_style.rs
@@ -17,30 +17,39 @@ pub struct ContentStyle {
 
 impl ContentStyle {
     /// Creates a `StyledContent` by applying the style to the given `val`.
-    pub fn apply<D: Display + Clone>(&self, val: D) -> StyledContent<D> {
-        StyledContent::new(self.clone(), val)
+    #[inline]
+    pub fn apply<D: Display>(self, val: D) -> StyledContent<D> {
+        StyledContent::new(self, val)
     }
 
     /// Creates a new `ContentStyle`.
+    #[inline]
     pub fn new() -> ContentStyle {
         ContentStyle::default()
     }
 
     /// Sets the background color.
-    pub fn background(mut self, color: Color) -> ContentStyle {
-        self.background_color = Some(color);
-        self
+    #[inline]
+    pub fn background(self, color: Color) -> ContentStyle {
+        Self {
+            background_color: Some(color),
+            ..self
+        }
     }
 
     /// Sets the foreground color.
-    pub fn foreground(mut self, color: Color) -> ContentStyle {
-        self.foreground_color = Some(color);
-        self
+    #[inline]
+    pub fn foreground(self, color: Color) -> ContentStyle {
+        Self {
+            foreground_color: Some(color),
+            ..self
+        }
     }
 
     /// Adds the attribute.
     ///
     /// You can add more attributes by calling this method multiple times.
+    #[inline]
     pub fn attribute(mut self, attr: Attribute) -> ContentStyle {
         self.attributes.push(attr);
         self

--- a/src/style/styled_content.rs
+++ b/src/style/styled_content.rs
@@ -28,51 +28,70 @@ use crate::{
 /// println!("{}", styled);
 /// ```
 #[derive(Clone)]
-pub struct StyledContent<D: Display + Clone> {
+pub struct StyledContent<D: Display> {
     /// The style (colors, content attributes).
     style: ContentStyle,
     /// A content to apply the style on.
     content: D,
 }
 
-impl<'a, D: Display + 'a + Clone> StyledContent<D> {
+impl<D: Display> StyledContent<D> {
     /// Creates a new `StyledContent`.
+    #[inline]
     pub fn new(style: ContentStyle, content: D) -> StyledContent<D> {
         StyledContent { style, content }
     }
 
     /// Sets the foreground color.
-    pub fn with(mut self, foreground_color: Color) -> StyledContent<D> {
-        self.style = self.style.foreground(foreground_color);
-        self
+    #[inline]
+    pub fn with(self, foreground_color: Color) -> StyledContent<D> {
+        Self {
+            style: self.style.foreground(foreground_color),
+            ..self
+        }
     }
 
     /// Sets the background color.
-    pub fn on(mut self, background_color: Color) -> StyledContent<D> {
-        self.style = self.style.background(background_color);
-        self
+    #[inline]
+    pub fn on(self, background_color: Color) -> StyledContent<D> {
+        Self {
+            style: self.style.background(background_color),
+            ..self
+        }
     }
 
     /// Adds the attribute.
     ///
     /// You can add more attributes by calling this method multiple times.
-    pub fn attribute(mut self, attr: Attribute) -> StyledContent<D> {
-        self.style = self.style.attribute(attr);
-        self
+    #[inline]
+    pub fn attribute(self, attr: Attribute) -> StyledContent<D> {
+        Self {
+            style: self.style.attribute(attr),
+            ..self
+        }
     }
 
     /// Returns the content.
+    #[inline]
     pub fn content(&self) -> &D {
         &self.content
     }
 
     /// Returns the style.
+    #[inline]
     pub fn style(&self) -> &ContentStyle {
         &self.style
     }
+
+    /// Returns a mutable reference to the style, so that it can be futher
+    /// manipulated
+    #[inline]
+    pub fn style_mut(&mut self) -> &mut ContentStyle {
+        &mut self.style
+    }
 }
 
-impl<D: Display + Clone> Display for StyledContent<D> {
+impl<D: Display> Display for StyledContent<D> {
     fn fmt(&self, f: &mut Formatter<'_>) -> result::Result<(), fmt::Error> {
         let mut reset = false;
 
@@ -85,13 +104,16 @@ impl<D: Display + Clone> Display for StyledContent<D> {
             reset = true;
         }
 
-        for attr in self.style.attributes.iter() {
+        for attr in &self.style.attributes {
             queue!(f, SetAttribute(*attr)).map_err(|_| fmt::Error)?;
             reset = true;
         }
 
-        fmt::Display::fmt(&self.content, f)?;
+        self.content.fmt(f)?;
 
+        // TODO: There are specific command sequences for "reset forground
+        // color (39m)" and "reset background color (49m)"; consider using
+        // these.
         if reset {
             queue!(f, ResetColor).map_err(|_| fmt::Error)?;
         }


### PR DESCRIPTION
- Substantially simplified implementation of command queue macros, including some bug fixes
    - Fixed errors being usually ignored
- Cleaned up StyledContent and ContentStyle
    - Removed unneeded trait and lifetime bounds
    - made builder pattern methods more expression oriented, and added inlines
    - added StyledContent::style_mut

This PR includes a few breaking changes, only one of which actually matters:

- Changed ContentStyle::with to take `self` instead of `&self`. This is because the former version clones `self`, which includes `Vec` clone; these are generally considered bad practice when done secretly. I'm happy to revert this change if you still prefer the old version
- changes to `execute!` and `queue!`:
    - Added explicit support for queue 0: `queue!(stdout);` is now valid.
    - you can no longer double up on a trailing comma: `queue!(stdout,,);` is no longer valid.
    - they no longer ignore errors for the first N-1 queued events.
    - execute now only flushes once, after all events are queued, and returns an error instead of panicking on a flush error.