### PR TITLE
Fixes issue #371 (As much as is possible)

### DIFF
--- a/src/event/sys/unix/parse.rs
+++ b/src/event/sys/unix/parse.rs
@@ -73,9 +73,9 @@ pub(crate) fn parse_event(buffer: &[u8], input_available: bool) -> Result<Option
         // newlines as input is because the terminal converts \r into \n for us. When we
         // enter raw mode, we disable that, so \n no longer has any meaning - it's better to
         // use Ctrl+J. Waiting to handle it here means it gets picked up later
-        b'\n' if !crate::terminal::sys::is_raw_mode_enabled() => Ok(Some(InternalEvent::Event(Event::Key(
-            KeyCode::Enter.into(),
-        )))),
+        b'\n' if !crate::terminal::sys::is_raw_mode_enabled() => Ok(Some(InternalEvent::Event(
+            Event::Key(KeyCode::Enter.into()),
+        ))),
         b'\t' => Ok(Some(InternalEvent::Event(Event::Key(KeyCode::Tab.into())))),
         b'\x7F' => Ok(Some(InternalEvent::Event(Event::Key(
             KeyCode::Backspace.into(),


### PR DESCRIPTION
The key codes for newline ('\n') and Ctrl+J are both 0xA - this is given by the terminal, and there's not much we can do about that particular fact. As it turns out, terminals operating in "canonical mode" - i.e. not raw mode - will convert any carriage returns ('\r') into newline characters - *even though the user doesn't directly input newlines*.

When we enter raw mode, one of the things that gets disabled is this automatic conversion. Now, when we get newlines, there's no ambiguity; it must be Ctrl+J. Terminal apps (like vim) are then able to handle Ctrl+J separately because they make that distinction once in raw mode.

More info: [https://viewsourcecode.org/snaptoken/kilo/02.enteringRawMode.html#fix-ctrl-m](https://viewsourcecode.org/snaptoken/kilo/02.enteringRawMode.html#fix-ctrl-m); ICRNL bitflag in [termios](http://man7.org/linux/man-pages/man3/termios.3.html)

This commit (roughly speaking) changes changes event parsing of newlines to only be enabled while the terminal isn't in raw mode. Outside of raw mode, it doesn't seem possible to handle Enter and Ctrl+J separately without using some of the same features of `termios.h` that are used to enable raw mode.