### PR TITLE
Automatically close raw fd when finished using

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -91,7 +91,7 @@ mod read;
 mod source;
 #[cfg(feature = "event-stream")]
 mod stream;
-mod sys;
+pub(crate) mod sys;
 mod timeout;
 
 lazy_static! {


### PR DESCRIPTION
Getting the terminal size will leak a file descriptor currently. (https://github.com/crossterm-rs/crossterm/issues/382)

This uses the auto-closing logic to avoid this issue.