### PR TITLE
add NONE flag to KeyModifiers

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -337,6 +337,7 @@ bitflags! {
         const SHIFT = 0b0000_0001;
         const CONTROL = 0b0000_0010;
         const ALT = 0b0000_0100;
+        const NONE = 0b0000_0000;
     }
 }
 


### PR DESCRIPTION
This change allows for:
```rust
        match event::read()? {
            Event::Key(k) => match k {
                KeyEvent {
                    code: KeyCode::Char(ch),
                    modifiers: KeyModifiers::NONE,
                } => println!("char: {}", ch),
                _ => {}
            },
            _ => {}
        }
```
instead of:
```rust
match k {
    KeyEvent {
        code: KeyCode::Char(ch),
        modifiers,
    } if modifiers == KeyModifiers::empty() => {}
}
```