### PR TITLE
Issue 406: Keep FileDesc alive long enough for ioctl to work

### DIFF
--- a/src/terminal/sys/unix.rs
+++ b/src/terminal/sys/unix.rs
@@ -32,13 +32,8 @@ pub(crate) fn size() -> Result<(u16, u16)> {
         ws_ypixel: 0,
     };
 
-    let file = if let Ok(file) = File::open("/dev/tty") {
-        Some(FileDesc::new(file.into_raw_fd(), true))
-    } else {
-        None
-    };
-
-    let fd = if let Some(file) = file {
+    let file = File::open("/dev/tty").map(|file| (FileDesc::new(file.into_raw_fd(), true)));
+    let fd = if let Ok(file) = &file {
         file.raw_fd()
     } else {
         // Fallback to libc::STDOUT_FILENO if /dev/tty is missing

--- a/src/terminal/sys/unix.rs
+++ b/src/terminal/sys/unix.rs
@@ -32,8 +32,14 @@ pub(crate) fn size() -> Result<(u16, u16)> {
         ws_ypixel: 0,
     };
 
-    let fd = if let Ok(file) = File::open("/dev/tty") {
-        FileDesc::new(file.into_raw_fd(), true).raw_fd()
+    let file = if let Ok(file) = File::open("/dev/tty") {
+        Some(FileDesc::new(file.into_raw_fd(), true))
+    } else {
+        None
+    };
+
+    let fd = if let Some(file) = file {
+        file.raw_fd()
     } else {
         // Fallback to libc::STDOUT_FILENO if /dev/tty is missing
         STDOUT_FILENO


### PR DESCRIPTION
This PR is to tackle [issue 406](https://github.com/crossterm-rs/crossterm/issues/406)
`FileDesc` was being dropped before reaching the `ioctl` call

Now `FileDesc` is in a `Option` that may live long enough.
The fallback still exists, and now relies on the presence of a file descriptor