### PR TITLE
Added a note about the examples repo being deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ features = ["event-stream"]
 ### Other Resources
 
 - [API documentation](https://docs.rs/crossterm/)
-- [Examples repository](https://github.com/crossterm-rs/examples)
+- [Deprecated examples repository](https://github.com/crossterm-rs/examples)
 
 ## Used By
 


### PR DESCRIPTION
This adds the deprecated in front of the examples directory so it's clear that you're supposed to look in `examples/`