### PR TITLE
Add macros for `Colorize` and `Styler` impls, add an impl for `String`

### DIFF
--- a/src/style.rs
+++ b/src/style.rs
@@ -160,109 +160,13 @@ where
     ContentStyle::new().apply(val)
 }
 
-impl Colorize<&'static str> for &'static str {
-    // foreground colors
-    def_str_color!(foreground_color: black => Color::Black);
-    def_str_color!(foreground_color: dark_grey => Color::DarkGrey);
-    def_str_color!(foreground_color: red => Color::Red);
-    def_str_color!(foreground_color: dark_red => Color::DarkRed);
-    def_str_color!(foreground_color: green => Color::Green);
-    def_str_color!(foreground_color: dark_green => Color::DarkGreen);
-    def_str_color!(foreground_color: yellow => Color::Yellow);
-    def_str_color!(foreground_color: dark_yellow => Color::DarkYellow);
-    def_str_color!(foreground_color: blue => Color::Blue);
-    def_str_color!(foreground_color: dark_blue => Color::DarkBlue);
-    def_str_color!(foreground_color: magenta => Color::Magenta);
-    def_str_color!(foreground_color: dark_magenta => Color::DarkMagenta);
-    def_str_color!(foreground_color: cyan => Color::Cyan);
-    def_str_color!(foreground_color: dark_cyan => Color::DarkCyan);
-    def_str_color!(foreground_color: white => Color::White);
-    def_str_color!(foreground_color: grey => Color::Grey);
+impl_colorize!(String);
+impl_colorize!(&'static str);
+impl_colorize!(char);
 
-    // background colors
-    def_str_color!(background_color: on_black => Color::Black);
-    def_str_color!(background_color: on_dark_grey => Color::DarkGrey);
-    def_str_color!(background_color: on_red => Color::Red);
-    def_str_color!(background_color: on_dark_red => Color::DarkRed);
-    def_str_color!(background_color: on_green => Color::Green);
-    def_str_color!(background_color: on_dark_green => Color::DarkGreen);
-    def_str_color!(background_color: on_yellow => Color::Yellow);
-    def_str_color!(background_color: on_dark_yellow => Color::DarkYellow);
-    def_str_color!(background_color: on_blue => Color::Blue);
-    def_str_color!(background_color: on_dark_blue => Color::DarkBlue);
-    def_str_color!(background_color: on_magenta => Color::Magenta);
-    def_str_color!(background_color: on_dark_magenta => Color::DarkMagenta);
-    def_str_color!(background_color: on_cyan => Color::Cyan);
-    def_str_color!(background_color: on_dark_cyan => Color::DarkCyan);
-    def_str_color!(background_color: on_white => Color::White);
-    def_str_color!(background_color: on_grey => Color::Grey);
-}
-
-impl Colorize<char> for char {
-    // foreground colors
-    def_char_color!(foreground_color: black => Color::Black);
-    def_char_color!(foreground_color: dark_grey => Color::DarkGrey);
-    def_char_color!(foreground_color: red => Color::Red);
-    def_char_color!(foreground_color: dark_red => Color::DarkRed);
-    def_char_color!(foreground_color: green => Color::Green);
-    def_char_color!(foreground_color: dark_green => Color::DarkGreen);
-    def_char_color!(foreground_color: yellow => Color::Yellow);
-    def_char_color!(foreground_color: dark_yellow => Color::DarkYellow);
-    def_char_color!(foreground_color: blue => Color::Blue);
-    def_char_color!(foreground_color: dark_blue => Color::DarkBlue);
-    def_char_color!(foreground_color: magenta => Color::Magenta);
-    def_char_color!(foreground_color: dark_magenta => Color::DarkMagenta);
-    def_char_color!(foreground_color: cyan => Color::Cyan);
-    def_char_color!(foreground_color: dark_cyan => Color::DarkCyan);
-    def_char_color!(foreground_color: white => Color::White);
-    def_char_color!(foreground_color: grey => Color::Grey);
-
-    // background colors
-    def_char_color!(background_color: on_black => Color::Black);
-    def_char_color!(background_color: on_dark_grey => Color::DarkGrey);
-    def_char_color!(background_color: on_red => Color::Red);
-    def_char_color!(background_color: on_dark_red => Color::DarkRed);
-    def_char_color!(background_color: on_green => Color::Green);
-    def_char_color!(background_color: on_dark_green => Color::DarkGreen);
-    def_char_color!(background_color: on_yellow => Color::Yellow);
-    def_char_color!(background_color: on_dark_yellow => Color::DarkYellow);
-    def_char_color!(background_color: on_blue => Color::Blue);
-    def_char_color!(background_color: on_dark_blue => Color::DarkBlue);
-    def_char_color!(background_color: on_magenta => Color::Magenta);
-    def_char_color!(background_color: on_dark_magenta => Color::DarkMagenta);
-    def_char_color!(background_color: on_cyan => Color::Cyan);
-    def_char_color!(background_color: on_dark_cyan => Color::DarkCyan);
-    def_char_color!(background_color: on_white => Color::White);
-    def_char_color!(background_color: on_grey => Color::Grey);
-}
-
-impl Styler<&'static str> for &'static str {
-    def_str_attr!(reset => Attribute::Reset);
-    def_str_attr!(bold => Attribute::Bold);
-    def_str_attr!(underlined => Attribute::Underlined);
-    def_str_attr!(reverse => Attribute::Reverse);
-    def_str_attr!(dim => Attribute::Dim);
-    def_str_attr!(italic => Attribute::Italic);
-    def_str_attr!(negative => Attribute::Reverse);
-    def_str_attr!(slow_blink => Attribute::SlowBlink);
-    def_str_attr!(rapid_blink => Attribute::RapidBlink);
-    def_str_attr!(hidden => Attribute::Hidden);
-    def_str_attr!(crossed_out => Attribute::CrossedOut);
-}
-
-impl Styler<char> for char {
-    def_char_attr!(reset => Attribute::Reset);
-    def_char_attr!(bold => Attribute::Bold);
-    def_char_attr!(underlined => Attribute::Underlined);
-    def_char_attr!(reverse => Attribute::Reverse);
-    def_char_attr!(dim => Attribute::Dim);
-    def_char_attr!(italic => Attribute::Italic);
-    def_char_attr!(negative => Attribute::Reverse);
-    def_char_attr!(slow_blink => Attribute::SlowBlink);
-    def_char_attr!(rapid_blink => Attribute::RapidBlink);
-    def_char_attr!(hidden => Attribute::Hidden);
-    def_char_attr!(crossed_out => Attribute::CrossedOut);
-}
+impl_styler!(String);
+impl_styler!(&'static str);
+impl_styler!(char);
 
 /// Returns available color count.
 ///

--- a/src/style/macros.rs
+++ b/src/style/macros.rs
@@ -1,14 +1,45 @@
-macro_rules! def_attr {
-    ((), $name:ident => $attr:path) => {
-        fn $name(self) -> StyledContent<D> {
-            self.attribute($attr)
-        }
-    };
-}
+//! Defines the macros for repetitive styling implementations
 
-macro_rules! def_attr_generic {
-    ($attr_ty:ty, $name:ident => $attr:path) => {
-        fn $name(self) -> StyledContent<$attr_ty> {
+// There's a single core set of macros structure here that's essentially repeated twice; once for
+// implementing `Styler` and once for `Colorize`. We'll go through `Styler` as the example, knowing
+// that `Colorize` works in precisely the same manner.
+//
+// There are four macros in each group. For `Styler`, they are:
+//  * def_attr_base,
+//  * def_attr_generic,
+//  * impl_styler_callback, and
+//  * impl_styler
+//
+// Fundamentally, any implementation works in a similar fashion; many methods with near-identical
+// bodies are grouped together. There are additionally two types of implementors: so-called "base"
+// implementors (`char`, `String`, etc.) and a single "generic" implementor - 'StyledContent<D>'.
+//
+// We can visualize the macro expansion with a sort of pipeline:
+//
+//                                    /--------> def_attr_base
+//   [impl_styler ->] impl_styler_callback
+//                                    \--------> def_attr_generic
+//
+// The code-gen starts at 'impl_styler' for "base" implementors, and at 'impl_styler_callback' for
+// `StyledContent<D>`. From there, 'impl_styler_callback' either repeatedly calls 'def_attr_base'
+// or 'def_attr_generic' - this is determined by the 'callback' argument.
+//
+// 'def_attr_base' is used to provide the method bodies for base types, and 'def_attr_generic'
+// provides the method bodies for 'StyledContent<D>'.
+
+
+////////////////////////////////////////////////////////////////////////////////
+// `Styler` macros                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+
+// Produces a single method for a "base" Styler implementation
+//
+// The first argument is the type for which Styler is being implemented. Because this is the same
+// for all "base" types, we can collase them into a single macro.
+macro_rules! def_attr_base {
+    ($impl_ty:ty, $name:ident => $attr:path) => {
+        fn $name(self) -> StyledContent<$impl_ty> {
             StyledContent::new(
                 ContentStyle {
                     attributes: $attr.into(),
@@ -20,6 +51,22 @@ macro_rules! def_attr_generic {
     }
 }
 
+// Produces a single method within an implementation of Styler for 'StyledContent<D>'
+//
+// We give it an empty argument at the start so that it has the same "signature" as
+// 'def_attr_base', which takes a type as its first argument
+macro_rules! def_attr_generic {
+    ((), $name:ident => $attr:path) => {
+        fn $name(self) -> StyledContent<D> {
+            self.attribute($attr)
+        }
+    };
+}
+
+// Produces the set of methods inside the implementation, but not the outer block itself
+//
+// 'callback' should be either one of 'def_attr_base' or 'def_attr_generic'. Each expansion of
+// 'callback' produces a single method with the name given by the second argument.
 macro_rules! impl_styler_callback {
     ($callback:ident!($args:tt)) => {
         $callback!($args, reset => Attribute::Reset);
@@ -36,29 +83,30 @@ macro_rules! impl_styler_callback {
     }
 }
 
+// Produces the full implementation of Styler for "base" types
+//
+// This macro is mostly here for convenience; it's nice to not require writing out the
+// `impl Styler<..> for ..` for each base type.
 macro_rules! impl_styler {
     ($impl_ty:ty) => {
         impl Styler<$impl_ty> for $impl_ty {
-            impl_styler_callback!(def_attr_generic!($impl_ty));
+            impl_styler_callback!(def_attr_base!($impl_ty));
         }
     };
 }
 
-macro_rules! def_color {
-    ((), $side:ident: $name:ident => $color:path) => {
-        fn $name(self) -> StyledContent<D> {
-            StyledContent::new(
-                ContentStyle {
-                    $side: Some($color),
-                    ..self.style
-                },
-                self.content,
-            )
-        }
-    };
-}
 
-macro_rules! def_color_generic {
+////////////////////////////////////////////////////////////////////////////////
+// `Colorize` macros                                                          //
+//                                                                            //
+// These are effectively the same as the `Styler` macros described above, so  //
+// not much detail is repeated here. Where above we have 'def_attr_*', there  //
+// is 'def_color_*' here, and 'impl_colorize' takes the place of              //
+// 'impl_styler'.                                                             //
+////////////////////////////////////////////////////////////////////////////////
+
+
+macro_rules! def_color_base {
     ($color_ty:ty, $side:ident: $name:ident => $color:path) => {
         fn $name(self) -> StyledContent<$color_ty> {
             StyledContent::new(
@@ -72,8 +120,23 @@ macro_rules! def_color_generic {
     };
 }
 
+macro_rules! def_color_generic {
+    ((), $side:ident: $name:ident => $color:path) => {
+        fn $name(self) -> StyledContent<D> {
+            StyledContent::new(
+                ContentStyle {
+                    $side: Some($color),
+                    ..self.style
+                },
+                self.content,
+            )
+        }
+    };
+}
+
 macro_rules! impl_colorize_callback {
     ($callback:ident!($args:tt)) => {
+        // foreground colors
         $callback!($args, foreground_color: black => Color::Black);
         $callback!($args, foreground_color: dark_grey => Color::DarkGrey);
         $callback!($args, foreground_color: red => Color::Red);
@@ -114,7 +177,7 @@ macro_rules! impl_colorize_callback {
 macro_rules! impl_colorize {
     ($impl_ty:ty) => {
         impl Colorize<$impl_ty> for $impl_ty {
-            impl_colorize_callback!(def_color_generic!($impl_ty));
+            impl_colorize_callback!(def_color_base!($impl_ty));
         }
     };
 }

--- a/src/style/macros.rs
+++ b/src/style/macros.rs
@@ -1,13 +1,51 @@
 macro_rules! def_attr {
-    ($name:ident => $attr:path) => {
+    ((), $name:ident => $attr:path) => {
         fn $name(self) -> StyledContent<D> {
             self.attribute($attr)
         }
     };
 }
 
+macro_rules! def_attr_generic {
+    ($attr_ty:ty, $name:ident => $attr:path) => {
+        fn $name(self) -> StyledContent<$attr_ty> {
+            StyledContent::new(
+                ContentStyle {
+                    attributes: $attr.into(),
+                    ..Default::default()
+                },
+                self,
+            )
+        }
+    }
+}
+
+macro_rules! impl_styler_callback {
+    ($callback:ident!($args:tt)) => {
+        $callback!($args, reset => Attribute::Reset);
+        $callback!($args, bold => Attribute::Bold);
+        $callback!($args, underlined => Attribute::Underlined);
+        $callback!($args, reverse => Attribute::Reverse);
+        $callback!($args, dim => Attribute::Dim);
+        $callback!($args, italic => Attribute::Italic);
+        $callback!($args, negative => Attribute::Reverse);
+        $callback!($args, slow_blink => Attribute::SlowBlink);
+        $callback!($args, rapid_blink => Attribute::RapidBlink);
+        $callback!($args, hidden => Attribute::Hidden);
+        $callback!($args, crossed_out => Attribute::CrossedOut);
+    }
+}
+
+macro_rules! impl_styler {
+    ($impl_ty:ty) => {
+        impl Styler<$impl_ty> for $impl_ty {
+            impl_styler_callback!(def_attr_generic!($impl_ty));
+        }
+    };
+}
+
 macro_rules! def_color {
-    ($side:ident: $name:ident => $color:path) => {
+    ((), $side:ident: $name:ident => $color:path) => {
         fn $name(self) -> StyledContent<D> {
             StyledContent::new(
                 ContentStyle {
@@ -20,9 +58,9 @@ macro_rules! def_color {
     };
 }
 
-macro_rules! def_str_color {
-    ($side:ident: $name:ident => $color:path) => {
-        fn $name(self) -> StyledContent<&'static str> {
+macro_rules! def_color_generic {
+    ($color_ty:ty, $side:ident: $name:ident => $color:path) => {
+        fn $name(self) -> StyledContent<$color_ty> {
             StyledContent::new(
                 ContentStyle {
                     $side: Some($color),
@@ -34,44 +72,49 @@ macro_rules! def_str_color {
     };
 }
 
-macro_rules! def_char_color {
-    ($side:ident: $name:ident => $color:path) => {
-        fn $name(self) -> StyledContent<char> {
-            StyledContent::new(
-                ContentStyle {
-                    $side: Some($color),
-                    ..Default::default()
-                },
-                self,
-            )
-        }
+macro_rules! impl_colorize_callback {
+    ($callback:ident!($args:tt)) => {
+        $callback!($args, foreground_color: black => Color::Black);
+        $callback!($args, foreground_color: dark_grey => Color::DarkGrey);
+        $callback!($args, foreground_color: red => Color::Red);
+        $callback!($args, foreground_color: dark_red => Color::DarkRed);
+        $callback!($args, foreground_color: green => Color::Green);
+        $callback!($args, foreground_color: dark_green => Color::DarkGreen);
+        $callback!($args, foreground_color: yellow => Color::Yellow);
+        $callback!($args, foreground_color: dark_yellow => Color::DarkYellow);
+        $callback!($args, foreground_color: blue => Color::Blue);
+        $callback!($args, foreground_color: dark_blue => Color::DarkBlue);
+        $callback!($args, foreground_color: magenta => Color::Magenta);
+        $callback!($args, foreground_color: dark_magenta => Color::DarkMagenta);
+        $callback!($args, foreground_color: cyan => Color::Cyan);
+        $callback!($args, foreground_color: dark_cyan => Color::DarkCyan);
+        $callback!($args, foreground_color: white => Color::White);
+        $callback!($args, foreground_color: grey => Color::Grey);
+
+        // background colors
+        $callback!($args, background_color: on_black => Color::Black);
+        $callback!($args, background_color: on_dark_grey => Color::DarkGrey);
+        $callback!($args, background_color: on_red => Color::Red);
+        $callback!($args, background_color: on_dark_red => Color::DarkRed);
+        $callback!($args, background_color: on_green => Color::Green);
+        $callback!($args, background_color: on_dark_green => Color::DarkGreen);
+        $callback!($args, background_color: on_yellow => Color::Yellow);
+        $callback!($args, background_color: on_dark_yellow => Color::DarkYellow);
+        $callback!($args, background_color: on_blue => Color::Blue);
+        $callback!($args, background_color: on_dark_blue => Color::DarkBlue);
+        $callback!($args, background_color: on_magenta => Color::Magenta);
+        $callback!($args, background_color: on_dark_magenta => Color::DarkMagenta);
+        $callback!($args, background_color: on_cyan => Color::Cyan);
+        $callback!($args, background_color: on_dark_cyan => Color::DarkCyan);
+        $callback!($args, background_color: on_white => Color::White);
+        $callback!($args, background_color: on_grey => Color::Grey);
     };
 }
 
-macro_rules! def_str_attr {
-    ($name:ident => $attr:path) => {
-        fn $name(self) -> StyledContent<&'static str> {
-            StyledContent::new(
-                ContentStyle {
-                    attributes: $attr.into(),
-                    ..Default::default()
-                },
-                self,
-            )
-        }
-    };
-}
-
-macro_rules! def_char_attr {
-    ($name:ident => $attr:path) => {
-        fn $name(self) -> StyledContent<char> {
-            StyledContent::new(
-                ContentStyle {
-                    attributes: $attr.into(),
-                    ..Default::default()
-                },
-                self,
-            )
+macro_rules! impl_colorize {
+    ($impl_ty:ty) => {
+        impl Colorize<$impl_ty> for $impl_ty {
+            impl_colorize_callback!(def_color_generic!($impl_ty));
         }
     };
 }

--- a/src/style/macros.rs
+++ b/src/style/macros.rs
@@ -27,11 +27,9 @@
 // 'def_attr_base' is used to provide the method bodies for base types, and 'def_attr_generic'
 // provides the method bodies for 'StyledContent<D>'.
 
-
 ////////////////////////////////////////////////////////////////////////////////
 // `Styler` macros                                                            //
 ////////////////////////////////////////////////////////////////////////////////
-
 
 // Produces a single method for a "base" Styler implementation
 //
@@ -48,7 +46,7 @@ macro_rules! def_attr_base {
                 self,
             )
         }
-    }
+    };
 }
 
 // Produces a single method within an implementation of Styler for 'StyledContent<D>'
@@ -95,7 +93,6 @@ macro_rules! impl_styler {
     };
 }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 // `Colorize` macros                                                          //
 //                                                                            //
@@ -104,7 +101,6 @@ macro_rules! impl_styler {
 // is 'def_color_*' here, and 'impl_colorize' takes the place of              //
 // 'impl_styler'.                                                             //
 ////////////////////////////////////////////////////////////////////////////////
-
 
 macro_rules! def_color_base {
     ($color_ty:ty, $side:ident: $name:ident => $color:path) => {

--- a/src/style/macros.rs
+++ b/src/style/macros.rs
@@ -7,7 +7,7 @@
 // There are four macros in each group. For `Styler`, they are:
 //  * def_attr_base,
 //  * def_attr_generic,
-//  * impl_styler_callback, and
+//  * impl_styler_callback, 
 //  * impl_styler
 //
 // Fundamentally, any implementation works in a similar fashion; many methods with near-identical

--- a/src/style/styled_content.rs
+++ b/src/style/styled_content.rs
@@ -123,55 +123,11 @@ impl<D: Display> Display for StyledContent<D> {
 }
 
 impl<D: Display + Clone> Colorize<D> for StyledContent<D> {
-    // foreground colors
-    def_color!(foreground_color: black => Color::Black);
-    def_color!(foreground_color: dark_grey => Color::DarkGrey);
-    def_color!(foreground_color: red => Color::Red);
-    def_color!(foreground_color: dark_red => Color::DarkRed);
-    def_color!(foreground_color: green => Color::Green);
-    def_color!(foreground_color: dark_green => Color::DarkGreen);
-    def_color!(foreground_color: yellow => Color::Yellow);
-    def_color!(foreground_color: dark_yellow => Color::DarkYellow);
-    def_color!(foreground_color: blue => Color::Blue);
-    def_color!(foreground_color: dark_blue => Color::DarkBlue);
-    def_color!(foreground_color: magenta => Color::Magenta);
-    def_color!(foreground_color: dark_magenta => Color::DarkMagenta);
-    def_color!(foreground_color: cyan => Color::Cyan);
-    def_color!(foreground_color: dark_cyan => Color::DarkCyan);
-    def_color!(foreground_color: white => Color::White);
-    def_color!(foreground_color: grey => Color::Grey);
-
-    // background colors
-    def_color!(background_color: on_black => Color::Black);
-    def_color!(background_color: on_dark_grey => Color::DarkGrey);
-    def_color!(background_color: on_red => Color::Red);
-    def_color!(background_color: on_dark_red => Color::DarkRed);
-    def_color!(background_color: on_green => Color::Green);
-    def_color!(background_color: on_dark_green => Color::DarkGreen);
-    def_color!(background_color: on_yellow => Color::Yellow);
-    def_color!(background_color: on_dark_yellow => Color::DarkYellow);
-    def_color!(background_color: on_blue => Color::Blue);
-    def_color!(background_color: on_dark_blue => Color::DarkBlue);
-    def_color!(background_color: on_magenta => Color::Magenta);
-    def_color!(background_color: on_dark_magenta => Color::DarkMagenta);
-    def_color!(background_color: on_cyan => Color::Cyan);
-    def_color!(background_color: on_dark_cyan => Color::DarkCyan);
-    def_color!(background_color: on_white => Color::White);
-    def_color!(background_color: on_grey => Color::Grey);
+    impl_colorize_callback!(def_color!(()));
 }
 
 impl<D: Display + Clone> Styler<D> for StyledContent<D> {
-    def_attr!(reset => Attribute::Reset);
-    def_attr!(bold => Attribute::Bold);
-    def_attr!(underlined => Attribute::Underlined);
-    def_attr!(reverse => Attribute::Reverse);
-    def_attr!(dim => Attribute::Dim);
-    def_attr!(italic => Attribute::Italic);
-    def_attr!(negative => Attribute::Reverse);
-    def_attr!(slow_blink => Attribute::SlowBlink);
-    def_attr!(rapid_blink => Attribute::RapidBlink);
-    def_attr!(hidden => Attribute::Hidden);
-    def_attr!(crossed_out => Attribute::CrossedOut);
+    impl_styler_callback!(def_attr!(()));
 }
 
 #[cfg(test)]

--- a/src/style/styled_content.rs
+++ b/src/style/styled_content.rs
@@ -123,11 +123,11 @@ impl<D: Display> Display for StyledContent<D> {
 }
 
 impl<D: Display + Clone> Colorize<D> for StyledContent<D> {
-    impl_colorize_callback!(def_color!(()));
+    impl_colorize_callback!(def_color_generic!(()));
 }
 
 impl<D: Display + Clone> Styler<D> for StyledContent<D> {
-    impl_styler_callback!(def_attr!(()));
+    impl_styler_callback!(def_attr_generic!(()));
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Per the commit message:
> This shifts the bulk of the repeated code into style/macros.rs, and
switches to using it for all of the implementations of the two traits.
>
> It also adds new implementations of `Colorize` and `Styler` for
`String`.

I found myself wanting an implementation of `Colorize` for `String`, so I figured I'd collapse the existing macros to make that implementation easier. There are two sets of new macros to look at - one for each trait. I'll just describe the one for `Colorize`, but it's nearly identical for `Styler`.

There are three new macros: `def_color_generic`, `impl_colorize`, and `impl_colorize_callback`. The first of these just collects the common elements from `def_str_color` and `def_char_color` as the only difference was the return type of the produced method:

```rust
// First, the two previous macros:

macro_rules! def_str_color {
    ($side:ident: $name:ident => $color:path) => {
        fn $name(self) -> StyledContent<&'static str> {
            StyledContent::new(
                ContentStyle {
                    $side: Some($color),
                    ..Default::default()
                },
                self,
            )
        }
    };
}

macro_rules! def_char_color {
    ($side:ident: $name:ident => $color:path) => {
        fn $name(self) -> StyledContent<char> {
            StyledContent::new(
                ContentStyle {
                    $side: Some($color),
                    ..Default::default()
                },
                self,
            )
        }
    };
}

// And now the new one:

macro_rules! def_color_generic {
    ($color_ty:ty, $side:ident: $name:ident => $color:path) => {
        fn $name(self) -> StyledContent<$color_ty> {
            StyledContent::new(
                ContentStyle {
                    $side: Some($color),
                    ..Default::default()
                },
                self,
            )
        }
    };
}
```

There was a similar process for collecting the actual `impl` blocks themselves. The blocks for the three basic types (`char`, `&'static str`, and `String`) are all created via `impl_colorize`. The more complicated implementation for `StyledContent<D>` is done by the `impl_colorize_callback` macro, which takes one of `def_color_generic` or `def_color` as input to produce the value.

I'm not certain what the best names are for these macros; the current ones might be counter-intuitive, but I actually don't know. I just picked something.

I would also be happy to add some comments describing the macros if that's something that would be valuable.