### PR TITLE
Add raw mode guard

### DIFF
--- a/src/style/macros.rs
+++ b/src/style/macros.rs
@@ -7,7 +7,7 @@
 // There are four macros in each group. For `Styler`, they are:
 //  * def_attr_base,
 //  * def_attr_generic,
-//  * impl_styler_callback, 
+//  * impl_styler_callback,
 //  * impl_styler
 //
 // Fundamentally, any implementation works in a similar fashion; many methods with near-identical

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -107,6 +107,40 @@ pub fn disable_raw_mode() -> Result<()> {
     sys::disable_raw_mode()
 }
 
+/// A guard which automatically enters raw mode when created and automatically exits it when
+/// destroyed.
+///
+/// Please have a look at the [raw mode](../#raw-mode) section.
+///
+/// # Example
+///
+/// ```
+/// use crossterm::terminal::RawModeGuard;
+///
+/// {
+///     let _raw = RawModeGuard::new();
+///     // In raw mode
+/// }
+/// // No longer in raw mode
+/// ```
+#[non_exhaustive]
+#[derive(Debug)]
+pub struct RawModeGuard {}
+
+impl RawModeGuard {
+    /// Creates a new RawModeGuard and enters raw mode.
+    pub fn new() -> Result<Self> {
+        sys::enable_raw_mode()?;
+        Ok(Self {})
+    }
+}
+
+impl Drop for RawModeGuard {
+    fn drop(&mut self) {
+        let _ = sys::disable_raw_mode();
+    }
+}
+
 /// Returns the terminal size `(columns, rows)`.
 ///
 /// The top left cell is represented `(1, 1)`.


### PR DESCRIPTION
This PR adds `crossterm::terminal::RawModeGuard`, a type which enters raw mode when created and exits raw mode when destroyed.

The motivation for this is in applications that could panic - currently, if you run `enter_raw_mode()` and then panic the terminal gets all messed up if you try to use it again because it's still in raw mode. Having this type would prevent that, as its destructor would still be run even on panic.