### PR TITLE
Implementing `SetTitle` command

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -18,6 +18,7 @@ pub enum ErrorKind {
     Utf8Error(std::string::FromUtf8Error),
     ParseIntError(std::num::ParseIntError),
     ResizingTerminalFailure(String),
+    SettingTerminalTitleFailure,
     #[doc(hidden)]
     __Nonexhaustive,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,7 @@
 //!     [`ScrollDown`](terminal/struct.ScrollDown.html)
 //!   - Miscellaneous - [`Clear`](terminal/struct.Clear.html),
 //!     [`SetSize`](terminal/struct.SetSize.html)
+//!     [`SetTitle`](terminal/struct.SetTitle.html)
 //!   - Alternate screen - [`EnterAlternateScreen`](terminal/struct.EnterAlternateScreen.html),
 //!     [`LeaveAlternateScreen`](terminal/struct.LeaveAlternateScreen.html)
 //!

--- a/src/style/macros.rs
+++ b/src/style/macros.rs
@@ -7,7 +7,7 @@
 // There are four macros in each group. For `Styler`, they are:
 //  * def_attr_base,
 //  * def_attr_generic,
-//  * impl_styler_callback, 
+//  * impl_styler_callback,
 //  * impl_styler
 //
 // Fundamentally, any implementation works in a similar fashion; many methods with near-identical

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -303,7 +303,7 @@ impl Command for SetSize {
 }
 
 /// A command that sets the terminal title
-/// 
+///
 /// # Notes
 ///
 /// Commands must be executed/queued for execution otherwise they do nothing.

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -302,6 +302,26 @@ impl Command for SetSize {
     }
 }
 
+/// A command that sets the terminal title
+/// 
+/// # Notes
+///
+/// Commands must be executed/queued for execution otherwise they do nothing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SetTitle<'a>(pub &'a str);
+
+impl<'a> Command for SetTitle<'a> {
+    type AnsiType = String;
+
+    fn ansi_code(&self) -> Self::AnsiType {
+        ansi::set_title_ansi_sequence(self.0)
+    }
+
+    fn execute_winapi(&self) -> Result<()> {
+        sys::set_window_title(self.0)
+    }
+}
+
 impl_display!(for ScrollUp);
 impl_display!(for ScrollDown);
 impl_display!(for SetSize);

--- a/src/terminal/ansi.rs
+++ b/src/terminal/ansi.rs
@@ -21,3 +21,7 @@ pub(crate) fn scroll_down_csi_sequence(count: u16) -> String {
 pub(crate) fn set_size_csi_sequence(width: u16, height: u16) -> String {
     format!(csi!("8;{};{}t"), height, width)
 }
+
+pub(crate) fn set_title_ansi_sequence(title: &str) -> String {
+    format!("\x1B]0;{}\x07", title)
+}

--- a/src/terminal/sys.rs
+++ b/src/terminal/sys.rs
@@ -4,7 +4,8 @@
 pub(crate) use self::unix::{disable_raw_mode, enable_raw_mode, is_raw_mode_enabled, size};
 #[cfg(windows)]
 pub(crate) use self::windows::{
-    clear, disable_raw_mode, enable_raw_mode, scroll_down, scroll_up, set_size, size, set_window_title,
+    clear, disable_raw_mode, enable_raw_mode, scroll_down, scroll_up, set_size, set_window_title,
+    size,
 };
 
 #[cfg(windows)]

--- a/src/terminal/sys.rs
+++ b/src/terminal/sys.rs
@@ -4,7 +4,7 @@
 pub(crate) use self::unix::{disable_raw_mode, enable_raw_mode, is_raw_mode_enabled, size};
 #[cfg(windows)]
 pub(crate) use self::windows::{
-    clear, disable_raw_mode, enable_raw_mode, scroll_down, scroll_up, set_size, size,
+    clear, disable_raw_mode, enable_raw_mode, scroll_down, scroll_up, set_size, size, set_window_title,
 };
 
 #[cfg(windows)]

--- a/src/terminal/sys/windows.rs
+++ b/src/terminal/sys/windows.rs
@@ -191,7 +191,8 @@ pub(crate) fn set_size(width: u16, height: u16) -> Result<()> {
 }
 
 pub(crate) fn set_window_title(title: &str) -> Result<()> {
-    let title: Vec<_> = title.encode_utf16().collect();
+    let mut title: Vec<_> = title.encode_utf16().collect();
+    title.push(0);
     let result = unsafe { SetConsoleTitleW(title.as_ptr()) };
     if result != 0 {
         Ok(())
@@ -368,6 +369,6 @@ mod tests {
         assert_ne!(0, length);
 
         let console_title = OsString::from_wide(&raw[..length]).into_string().unwrap();
-        assert_eq!(test_title, console_title);
+        assert_eq!(test_title, &console_title[..]);
     }
 }

--- a/src/terminal/sys/windows.rs
+++ b/src/terminal/sys/windows.rs
@@ -293,10 +293,11 @@ fn clear_winapi(start_location: Coord, cells_to_write: u32, current_attribute: u
 
 #[cfg(test)]
 mod tests {
-    use crossterm_winapi::ScreenBuffer;
-    use std::ffi::OsString;
-    use std::os::windows::ffi::OsStringExt;
+    use std::{ffi::OsString, os::windows::ffi::OsStringExt};
+
     use winapi::um::wincon::GetConsoleTitleW;
+
+    use crossterm_winapi::ScreenBuffer;
 
     use super::{scroll_down, scroll_up, set_size, set_window_title, size};
 


### PR DESCRIPTION
Following our discussion in #347, this is my PR implementing it.

`src/terminal/sys/windows.rs` now has `set_window_title(title: &str) -> Result<()>`
It can fail with `ErrorKind::SettingTerminalTitleFailure` (do you think there should be extra info inside this variant? We'd have to call [GetLastError](https://docs.microsoft.com/en-us/windows/win32/api/errhandlingapi/nf-errhandlingapi-getlasterror?redirectedfrom=MSDN)).

What I'm not sure about is the `terminal::ansi::set_title_ansi_sequence(title: &str) -> String`. That is because it seems that setting the terminal title is not a CSI sequence (it starts with `\x1B]` instead of `\x1B[`) so I just did left the sequence there inside the `format!` instead of wrapping it inside a macro or something.

Besides that, you can find the command struct `SetTitle` inside `src/terminal.rs`. It has a straightforward implementation. From what I understand, that is enough to only use the ansi version on platforms that support it, correct?

That's it!