### PR TITLE
WIP mio update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 0.17.5
+- Improved support of keymodifier for linux, arrow keys, function keys, home keys etc.
+- Add `SetTitle` command to change the terminal title.
+- Mio 0.7 update
+
 # Version 0.17.4
 - Add macros for `Colorize` and `Styler` impls, add an impl for `String` 
 - Add shift modifier to uppercase char events on unix 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,8 +54,8 @@ crossterm_winapi = "0.6.1"
 #
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
-mio = "0.6"
-signal-hook = { version = "0.1.13", features = ["mio-support"] }
+mio = {version="0.7", features=["os-poll"]}
+signal-hook = { version = "0.1.15", features = ["mio-0_7-support"] }
 
 #
 # Dev dependencies (examples, ...)

--- a/examples/event-stream-tokio.rs
+++ b/examples/event-stream-tokio.rs
@@ -43,7 +43,7 @@ async fn print_events() {
                             println!("Cursor position: {:?}\r", position());
                         }
 
-                        if event == Event::Key(KeyCode::Up.into()) {
+                        if event == Event::Key(KeyCode::Esc.into()) {
                             break;
                         }
                     }

--- a/src/event/source/unix.rs
+++ b/src/event/source/unix.rs
@@ -139,7 +139,6 @@ impl EventSource for UnixInternalEventSource {
                     }
                     #[cfg(feature = "event-stream")]
                     WAKE_TOKEN => {
-                        println!("WAKE TOKEN");
                         return Err(std::io::Error::new(
                             std::io::ErrorKind::Interrupted,
                             "Poll operation was woken up by `Waker::wake`",

--- a/src/event/source/unix.rs
+++ b/src/event/source/unix.rs
@@ -94,9 +94,6 @@ impl EventSource for UnixInternalEventSource {
                             match self.tty_fd.read(&mut self.tty_buffer, TTY_BUFFER_SIZE) {
                                 Ok(read_count) => {
                                     if read_count > 0 {
-                                        self.poll
-                                            .poll(&mut additional_input_events, Some(Duration::from_secs(0)))?;
-
                                         self.parser.advance(
                                             &self.tty_buffer[..read_count],
                                             false,

--- a/src/event/source/unix.rs
+++ b/src/event/source/unix.rs
@@ -1,8 +1,8 @@
 use mio::{unix::SourceFd, Events, Interest, Poll, Token};
 use signal_hook::iterator::Signals;
-use std::{collections::VecDeque, time::Duration, io};
+use std::{collections::VecDeque, io, time::Duration};
 
-use crate::{Result, ErrorKind};
+use crate::{ErrorKind, Result};
 
 #[cfg(feature = "event-stream")]
 use super::super::sys::Waker;
@@ -99,12 +99,16 @@ impl EventSource for UnixInternalEventSource {
                                             read_count == TTY_BUFFER_SIZE,
                                         );
                                     }
-                                },
+                                }
                                 Err(ErrorKind::IoError(e)) => {
                                     // No more data to read at the moment. We will receive another event
-                                    if e.kind() == io::ErrorKind::WouldBlock { break }
+                                    if e.kind() == io::ErrorKind::WouldBlock {
+                                        break;
+                                    }
                                     // once more data is available to read.
-                                    else if e.kind() == io::ErrorKind::Interrupted {continue}
+                                    else if e.kind() == io::ErrorKind::Interrupted {
+                                        continue;
+                                    }
                                 }
                                 Err(e) => return Err(e),
                             };

--- a/src/event/source/unix.rs
+++ b/src/event/source/unix.rs
@@ -96,7 +96,7 @@ impl EventSource for UnixInternalEventSource {
                                     if read_count > 0 {
                                         self.parser.advance(
                                             &self.tty_buffer[..read_count],
-                                            false,
+                                            read_count == TTY_BUFFER_SIZE,
                                         );
                                     }
                                 },

--- a/src/event/sys/unix/waker.rs
+++ b/src/event/sys/unix/waker.rs
@@ -1,42 +1,13 @@
-// TODO Replace with `mio::Waker` when the 0.7 is released (not available in 0.6).
-
 use std::sync::{Arc, Mutex};
 
-use mio::{Evented, Poll, PollOpt, Ready, Registration, SetReadiness, Token};
+use mio::{Token, Registry};
 
-use crate::Result;
-
-#[derive(Debug)]
-struct WakerInner {
-    registration: Registration,
-    set_readiness: SetReadiness,
-}
-
-impl WakerInner {
-    fn new() -> Self {
-        let (registration, set_readiness) = Registration::new2();
-
-        Self {
-            registration,
-            set_readiness,
-        }
-    }
-
-    fn wake(&self) -> Result<()> {
-        self.set_readiness.set_readiness(Ready::readable())?;
-        Ok(())
-    }
-
-    fn reset(&self) -> Result<()> {
-        self.set_readiness.set_readiness(Ready::empty())?;
-        Ok(())
-    }
-}
+use crate::{Result, ErrorKind};
 
 /// Allows to wake up the `mio::Poll::poll()` method.
 #[derive(Clone, Debug)]
 pub(crate) struct Waker {
-    inner: Arc<Mutex<WakerInner>>,
+    inner: Arc<Mutex<mio::Waker>>,
 }
 
 impl Waker {
@@ -44,9 +15,9 @@ impl Waker {
     ///
     /// `Waker` implements the `mio::Evented` trait and you have to register
     /// it in order to use it.
-    pub(crate) fn new() -> Result<Self> {
+    pub(crate) fn new(registry: &Registry, waker_token: Token) -> Result<Self> {
         Ok(Self {
-            inner: Arc::new(Mutex::new(WakerInner::new())),
+            inner: Arc::new(Mutex::new(mio::Waker::new(registry, waker_token)?)),
         })
     }
 
@@ -55,47 +26,13 @@ impl Waker {
     /// Readiness is set to `Ready::readable()`.
     pub(crate) fn wake(&self) -> Result<()> {
         self.inner.lock().unwrap().wake()
+            .map_err(|e| ErrorKind::IoError(e))
     }
 
     /// Resets the state so the same waker can be reused.
     ///
     /// Readiness is set back to `Ready::empty()`.
     pub(crate) fn reset(&self) -> Result<()> {
-        self.inner.lock().unwrap().reset()
-    }
-}
-
-impl Evented for Waker {
-    fn register(
-        &self,
-        poll: &Poll,
-        token: Token,
-        interest: Ready,
-        opts: PollOpt,
-    ) -> ::std::io::Result<()> {
-        self.inner
-            .lock()
-            .unwrap()
-            .registration
-            .register(poll, token, interest, opts)
-    }
-
-    fn reregister(
-        &self,
-        poll: &Poll,
-        token: Token,
-        interest: Ready,
-        opts: PollOpt,
-    ) -> ::std::io::Result<()> {
-        self.inner
-            .lock()
-            .unwrap()
-            .registration
-            .reregister(poll, token, interest, opts)
-    }
-
-    #[allow(deprecated)]
-    fn deregister(&self, poll: &Poll) -> ::std::io::Result<()> {
-        self.inner.lock().unwrap().registration.deregister(poll)
+        Ok(())
     }
 }

--- a/src/event/sys/unix/waker.rs
+++ b/src/event/sys/unix/waker.rs
@@ -1,37 +1,38 @@
 use std::sync::{Arc, Mutex};
 
-use mio::{Token, Registry};
+use mio::{Registry, Token};
 
-use crate::{Result, ErrorKind};
+use crate::{ErrorKind, Result};
 
 /// Allows to wake up the `mio::Poll::poll()` method.
+/// This type wraps `mio::Waker`, for more information see its documentation.
 #[derive(Clone, Debug)]
 pub(crate) struct Waker {
     inner: Arc<Mutex<mio::Waker>>,
 }
 
 impl Waker {
-    /// Creates a new waker.
-    ///
-    /// `Waker` implements the `mio::Evented` trait and you have to register
-    /// it in order to use it.
+    /// Create a new `Waker`.
     pub(crate) fn new(registry: &Registry, waker_token: Token) -> Result<Self> {
         Ok(Self {
             inner: Arc::new(Mutex::new(mio::Waker::new(registry, waker_token)?)),
         })
     }
 
-    /// Wakes the `mio::Poll.poll()` method.
+    /// Wake up the [`Poll`] associated with this `Waker`.
     ///
     /// Readiness is set to `Ready::readable()`.
     pub(crate) fn wake(&self) -> Result<()> {
-        self.inner.lock().unwrap().wake()
+        self.inner
+            .lock()
+            .unwrap()
+            .wake()
             .map_err(|e| ErrorKind::IoError(e))
     }
 
     /// Resets the state so the same waker can be reused.
     ///
-    /// Readiness is set back to `Ready::empty()`.
+    /// This function is not impl
     pub(crate) fn reset(&self) -> Result<()> {
         Ok(())
     }


### PR DESCRIPTION
Attempt to update to the latest mio version.

- Replace our waker with the waker from [mio](https://docs.rs/mio/0.7.0/mio/struct.Waker.html).
- Updated to 0.7.

I have one concern about this update which is mentioned in the mio [change log](https://github.com/tokio-rs/mio/blob/master/CHANGELOG.md):

> PollOpt was removed and all registrations use edge-triggers. See the upgrade guide on how to process event using edge-triggers.

And @zrzka once commented this in the source code:

```
        // PollOpt::level vs PollOpt::edge mio documentation:
        //
        // > With edge-triggered events, operations must be performed on the Evented type until
        // > WouldBlock is returned.
        //
        // TL;DR - DO NOT use PollOpt::edge.
        //
        // Because of the `try_read` nature (loop with returns) we can't use `PollOpt::edge`. All
        // `Evented` handles MUST be registered with the `PollOpt::level`.
        //
        // If you have to use `PollOpt::edge` and there's no way how to do it with the `PollOpt::level`,
        // be aware that the whole `TtyInternalEventSource` have to be rewritten
        // (read everything from each `Evented`, process without returns, store all InternalEvent events
        // into a buffer and then return first InternalEvent, etc.). Even these changes wont be
        // enough, because `Poll::poll` wont fire again until additional `Evented` event happens and
        // we can still have a buffer filled with InternalEvent events.
```

@zrzka I tested with mio 0.7 but don't seem to have any problems with this in this branch. Do you still think that this issue is relevant, or do you have any new insights on this matter? 

