### PR TITLE
Fix terminology for Windows

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -23,5 +23,5 @@ A clear and concise description of what you expected to happen.
 **OS**
  - e.g. MacOs, Windows, Linux, (version) etc...
 
-**Terminal/Shell**
- - e.g. CMD/Powershell/ etc.
+**Terminal/Console**
+ - e.g. ConHost/xterm/iterm2/Windows Terminal etc.

--- a/README.md
+++ b/README.md
@@ -60,9 +60,7 @@ WARNING: Do not change following heading title as it's used in the URL by other 
 
 ### Tested Terminals
 
-- Windows Powershell
-    - Windows 10 (Pro)
-- Windows CMD
+- Console Host
     - Windows 10 (Pro)
     - Windows 8.1 (N)
 - Ubuntu Desktop Terminal


### PR DESCRIPTION
PowerShell and CMD are not terminals, they are shells.

This is related to issue #436.