### PR TITLE
Implement styler traits for `&'a str`

### DIFF
--- a/src/style.rs
+++ b/src/style.rs
@@ -161,12 +161,22 @@ where
 }
 
 impl_colorize!(String);
-impl_colorize!(&'static str);
 impl_colorize!(char);
 
+// We do actually need the parentheses here because the macro doesn't work without them otherwise
+// This is probably a bug somewhere in the compiler, but it isn't that big a deal.
+#[allow(unused_parens)]
+impl<'a> Colorize<&'a str> for &'a str {
+    impl_colorize_callback!(def_color_base!((&'a str)));
+}
+
 impl_styler!(String);
-impl_styler!(&'static str);
 impl_styler!(char);
+
+#[allow(unused_parens)]
+impl<'a> Styler<&'a str> for &'a str {
+    impl_styler_callback!(def_attr_base!((&'a str)));
+}
 
 /// Returns available color count.
 ///


### PR DESCRIPTION
I ran into a case where I wanted an implementation of `Colorize` for `&'a str`, not just `&'static str`, so I added it in. There's a weird case where some parentheses are required to compile but marked by the compiler as unnecessary, so I put `#[allow(unused_parens)]` alongside a little coment about them.

The change was (thankfully) relatively simple - just moving the implementation for `str` to use the more specialized macro instead.