### PR TITLE
windows: {enable,disable}_raw_mode on CONIN$

### DIFF
--- a/src/terminal/sys/windows.rs
+++ b/src/terminal/sys/windows.rs
@@ -10,7 +10,7 @@ use crate::{cursor, terminal::ClearType, ErrorKind, Result};
 const RAW_MODE_MASK: DWORD = ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT | ENABLE_PROCESSED_INPUT;
 
 pub(crate) fn enable_raw_mode() -> Result<()> {
-    let console_mode = ConsoleMode::from(Handle::input_handle()?);
+    let console_mode = ConsoleMode::from(Handle::current_in_handle()?);
 
     let dw_mode = console_mode.mode()?;
 
@@ -22,7 +22,7 @@ pub(crate) fn enable_raw_mode() -> Result<()> {
 }
 
 pub(crate) fn disable_raw_mode() -> Result<()> {
-    let console_mode = ConsoleMode::from(Handle::input_handle()?);
+    let console_mode = ConsoleMode::from(Handle::current_in_handle()?);
 
     let dw_mode = console_mode.mode()?;
 


### PR DESCRIPTION
On Windows, `enable_raw_mode` and `disable_raw_mode` were attempting to
read the mode from `Handle::input_handle()`, which resolves to the
result of `GetStdHandle(STD_INPUT_HANDLE)`. When stdin is not piped,
this works fine because that call will resolve to `CONIN$`. However,
when stdin is piped, the call will fail because `GetConsoleMode()` only
operates on Console handles, not pipes.

Changing this to always operate on `Handle::current_in_handle()`, which
always resolves to `CONIN$`, results in being able to enable/disable raw
mode on the console. This allows for using crossterm on Windows when
stdin is a pipe.

Fixes #452