### PR TITLE
Switch from 'futures' to 'futures-util' crate to reduce dependency count

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ all-features = true
 #
 [features]
 default = []
-event-stream = ["futures"]
+event-stream = ["futures-util"]
 
 #
 # Shared dependencies
@@ -36,7 +36,7 @@ event-stream = ["futures"]
 bitflags = "1.2"
 lazy_static = "1.4"
 parking_lot = "0.10"
-futures = { version = "0.3", optional = true }
+futures-util = { version = "0.3", optional = true, default-features = false }
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 #

--- a/examples/event-stream-async-std.rs
+++ b/examples/event-stream-async-std.rs
@@ -7,8 +7,8 @@ use std::{
     time::Duration,
 };
 
-use futures::{future::FutureExt, select, StreamExt};
 use futures_timer::Delay;
+use futures_util::{future::FutureExt, select, StreamExt};
 
 use crossterm::{
     cursor::position,
@@ -18,7 +18,7 @@ use crossterm::{
     Result,
 };
 
-const HELP: &str = r#"EventStream based on futures::Stream with async-std
+const HELP: &str = r#"EventStream based on futures_util::stream::Stream with async-std
  - Keyboard, mouse and terminal resize events enabled
  - Prints "." every second if there's no event
  - Hit "c" to print current cursor position

--- a/examples/event-stream-tokio.rs
+++ b/examples/event-stream-tokio.rs
@@ -7,8 +7,8 @@ use std::{
     time::Duration,
 };
 
-use futures::{future::FutureExt, select, StreamExt};
 use futures_timer::Delay;
+use futures_util::{future::FutureExt, select, StreamExt};
 
 use crossterm::{
     cursor::position,
@@ -18,7 +18,7 @@ use crossterm::{
     Result,
 };
 
-const HELP: &str = r#"EventStream based on futures::Stream with tokio
+const HELP: &str = r#"EventStream based on futures_util::Stream with tokio
  - Keyboard, mouse and terminal resize events enabled
  - Prints "." every second if there's no event
  - Hit "c" to print current cursor position

--- a/src/event/source/unix.rs
+++ b/src/event/source/unix.rs
@@ -45,7 +45,7 @@ impl UnixInternalEventSource {
 
     pub(crate) fn from_file_descriptor(input_fd: FileDesc) -> Result<Self> {
         let poll = Poll::new()?;
-        let mut registry = poll.registry();
+        let registry = poll.registry();
 
         let tty_raw_fd = input_fd.raw_fd();
         let mut tty_ev = SourceFd(&tty_raw_fd);
@@ -55,7 +55,7 @@ impl UnixInternalEventSource {
         registry.register(&mut signals, SIGNAL_TOKEN, Interest::READABLE)?;
 
         #[cfg(feature = "event-stream")]
-        let mut waker = Waker::new(registry, WAKE_TOKEN)?;
+        let waker = Waker::new(registry, WAKE_TOKEN)?;
 
         Ok(UnixInternalEventSource {
             poll,
@@ -77,7 +77,6 @@ impl EventSource for UnixInternalEventSource {
         }
 
         let timeout = PollTimeout::new(timeout);
-        let mut additional_input_events = Events::with_capacity(3);
 
         loop {
             self.poll.poll(&mut self.events, timeout.leftover())?;

--- a/src/event/stream.rs
+++ b/src/event/stream.rs
@@ -8,9 +8,9 @@ use std::{
     time::Duration,
 };
 
-use futures::{
+use futures_util::{
+    stream::Stream,
     task::{Context, Poll},
-    Stream,
 };
 
 use crate::Result;


### PR DESCRIPTION
This decreases initial compile times by 10s with the `event-stream`
feature selected.

* 1min 18s with this change
* 1min 29s without