### PR TITLE
Update Rust-sloth link in "Used By"

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ features = ["event-stream"]
 - [Broot](https://dystroy.org/broot/)
 - [Cursive](https://github.com/gyscos/Cursive)
 - [TUI](https://github.com/fdehau/tui-rs)
-- [Rust-sloth](https://github.com/jonathandturner/rust-sloth/tree/crossterm-port)
+- [Rust-sloth](https://github.com/ecumene/rust-sloth)
 
 ## Contributing
   


### PR DESCRIPTION
# Description

The Rust-sloth link was pointing to a fork of the repository that has since been merged to the main repository.

The fork was merged in https://github.com/ecumene/rust-sloth/pull/8 by @ecumene.