### PR TITLE
Incoherent derived traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ crossterm_winapi = "0.6.1"
 #
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
-mio = {version="0.7", features=["os-poll"]}
+mio = { version="0.7", features=["os-poll"] }
 signal-hook = { version = "0.1.15", features = ["mio-0_7-support"] }
 
 #
@@ -65,3 +65,14 @@ tokio = { version = "0.2.11", features = ["full"] }
 futures = "0.3"
 futures-timer = "3.0"
 async-std = "1.4"
+
+#
+# Examples
+#
+[[example]]
+name = "event-stream-async-std"
+required-features = ["event-stream"]
+
+[[example]]
+name = "event-stream-tokio"
+required-features = ["event-stream"]

--- a/src/style.rs
+++ b/src/style.rs
@@ -377,7 +377,7 @@ impl Command for SetAttributes {
 /// # Notes
 ///
 /// Commands must be executed/queued for execution otherwise they do nothing.
-#[derive(Debug, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct PrintStyledContent<D: Display + Clone>(pub StyledContent<D>);
 
 impl<D> Command for PrintStyledContent<D>

--- a/src/style/content_style.rs
+++ b/src/style/content_style.rs
@@ -5,7 +5,7 @@ use std::fmt::Display;
 use crate::style::{Attribute, Attributes, Color, StyledContent};
 
 /// The style that can be put on content.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Copy, Clone, Default)]
 pub struct ContentStyle {
     /// The foreground color.
     pub foreground_color: Option<Color>,

--- a/src/style/styled_content.rs
+++ b/src/style/styled_content.rs
@@ -27,7 +27,7 @@ use crate::{
 ///
 /// println!("{}", styled);
 /// ```
-#[derive(Clone, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub struct StyledContent<D: Display> {
     /// The style (colors, content attributes).
     style: ContentStyle,


### PR DESCRIPTION
This is a PR for #470.

It fixes `ContentStyle`, `StyledContent` and `PrintStyledContent` by adding a `Copy` auto-derive.
Note that everything else stated in the issue is left for the project author/maintainer as thoughts.

You might want to know that `$ rg derive -A 1` shows that (at least) `CursorPositionFilter`, `EventFilter` and `InternalEventFilter` also miss a `Copy` auto-derive.

As a bonus, this PR fixes the configuration for running the examples (features where missing, breaking `$ cargo test`).

**Failing tests on code that I did not write**
