### PR TITLE
Switching to futures-lite, reduces build time.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ all-features = true
 #
 [features]
 default = []
-event-stream = ["futures-util"]
+event-stream = ["futures-lite"]
 
 #
 # Shared dependencies
@@ -36,7 +36,7 @@ event-stream = ["futures-util"]
 bitflags = "1.2"
 lazy_static = "1.4"
 parking_lot = "0.10"
-futures-util = { version = "0.3", optional = true, default-features = false }
+futures-lite = { version = "1.0", optional = true, default-features = false }
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 #

--- a/examples/event-stream-async-std.rs
+++ b/examples/event-stream-async-std.rs
@@ -7,8 +7,8 @@ use std::{
     time::Duration,
 };
 
+use futures::{future::FutureExt, select, StreamExt};
 use futures_timer::Delay;
-use futures_util::{future::FutureExt, select, StreamExt};
 
 use crossterm::{
     cursor::position,

--- a/examples/event-stream-tokio.rs
+++ b/examples/event-stream-tokio.rs
@@ -7,8 +7,8 @@ use std::{
     time::Duration,
 };
 
+use futures::{future::FutureExt, select, StreamExt};
 use futures_timer::Delay;
-use futures_util::{future::FutureExt, select, StreamExt};
 
 use crossterm::{
     cursor::position,

--- a/src/event/stream.rs
+++ b/src/event/stream.rs
@@ -4,14 +4,12 @@ use std::{
         atomic::{AtomicBool, Ordering},
         Arc,
     },
+    task::{Context, Poll},
     thread,
     time::Duration,
 };
 
-use futures_util::{
-    stream::Stream,
-    task::{Context, Poll},
-};
+use futures_lite::stream::Stream;
 
 use crate::Result;
 


### PR DESCRIPTION
While using `tui` I noticed that my build time increased quite a bit when switching from the `termion` backend to `crossterm`. Updating `crossterm` to use [`futures-lite`](https://crates.io/crates/futures-lite) dropped the build time on my box by **15 seconds**.

Note: The build speed improvement only happens when using the `event-stream` feature.