### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -12,6 +12,7 @@ pub type Result<T> = std::result::Result<T, ErrorKind>;
 
 /// Wrapper for all errors that can occur in `crossterm`.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum ErrorKind {
     IoError(io::Error),
     FmtError(fmt::Error),
@@ -19,8 +20,6 @@ pub enum ErrorKind {
     ParseIntError(std::num::ParseIntError),
     ResizingTerminalFailure(String),
     SettingTerminalTitleFailure,
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 impl std::error::Error for ErrorKind {

--- a/src/event/filter.rs
+++ b/src/event/filter.rs
@@ -13,11 +13,7 @@ pub(crate) struct CursorPositionFilter;
 #[cfg(unix)]
 impl Filter for CursorPositionFilter {
     fn eval(&self, event: &InternalEvent) -> bool {
-        if let InternalEvent::CursorPosition(_, _) = *event {
-            true
-        } else {
-            false
-        }
+        matches!(*event, InternalEvent::CursorPosition(_, _))
     }
 }
 
@@ -27,11 +23,7 @@ pub(crate) struct EventFilter;
 impl Filter for EventFilter {
     #[cfg(unix)]
     fn eval(&self, event: &InternalEvent) -> bool {
-        if let InternalEvent::Event(_) = *event {
-            true
-        } else {
-            false
-        }
+        matches!(*event, InternalEvent::Event(_))
     }
 
     #[cfg(windows)]

--- a/src/style/types/attribute.rs
+++ b/src/style/types/attribute.rs
@@ -88,6 +88,7 @@ macro_rules! Attribute {
     }
 }
 
+#[non_exhaustive]
 Attribute! {
     /// Resets all the attributes.
     Reset = 0,
@@ -139,8 +140,6 @@ Attribute! {
     NotFramedOrEncircled = 54,
     /// Turns off the `OverLined` attribute.
     NotOverLined = 55,
-    #[doc(hidden)]
-    __Nonexhaustive = 255,
 }
 
 impl Display for Attribute {

--- a/src/terminal/sys/unix.rs
+++ b/src/terminal/sys/unix.rs
@@ -22,7 +22,7 @@ pub(crate) fn is_raw_mode_enabled() -> bool {
     TERMINAL_MODE_PRIOR_RAW_MODE.lock().unwrap().is_some()
 }
 
-#[allow(clippy::identity_conversion)]
+#[allow(clippy::useless_conversion)]
 pub(crate) fn size() -> Result<(u16, u16)> {
     // http://rosettacode.org/wiki/Terminal_control/Dimensions#Library:_BSD_libc
     let mut size = winsize {


### PR DESCRIPTION
The current clippy warnings are causing the GitHub Actions build to fail. The rule has been renamed.