### PR TITLE
Rely on futures-core instead of futures-util to speed up compile.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ all-features = true
 #
 [features]
 default = []
-event-stream = ["futures-util"]
+event-stream = ["futures-core"]
 
 #
 # Shared dependencies
@@ -36,7 +36,7 @@ event-stream = ["futures-util"]
 bitflags = "1.2"
 lazy_static = "1.4"
 parking_lot = "0.10"
-futures-util = { version = "0.3", optional = true, default-features = false }
+futures-core = { version = "0.3", optional = true, default-features = false }
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 #

--- a/examples/event-stream-async-std.rs
+++ b/examples/event-stream-async-std.rs
@@ -7,8 +7,8 @@ use std::{
     time::Duration,
 };
 
+use futures::{future::FutureExt, select, StreamExt};
 use futures_timer::Delay;
-use futures_util::{future::FutureExt, select, StreamExt};
 
 use crossterm::{
     cursor::position,

--- a/examples/event-stream-tokio.rs
+++ b/examples/event-stream-tokio.rs
@@ -7,8 +7,8 @@ use std::{
     time::Duration,
 };
 
+use futures::{future::FutureExt, select, StreamExt};
 use futures_timer::Delay;
-use futures_util::{future::FutureExt, select, StreamExt};
 
 use crossterm::{
     cursor::position,

--- a/src/event/stream.rs
+++ b/src/event/stream.rs
@@ -8,7 +8,7 @@ use std::{
     time::Duration,
 };
 
-use futures_util::{
+use futures_core::{
     stream::Stream,
     task::{Context, Poll},
 };


### PR DESCRIPTION
Before:
```
├── crossterm v0.17.7
│   ├── bitflags v1.2.1
│   ├── futures-util v0.3.5
│   │   ├── futures-core v0.3.5
│   │   ├── futures-task v0.3.5
│   │   ├── pin-project v0.4.23
│   │   │   └── pin-project-internal v0.4.23
│   │   │       ├── proc-macro2 v1.0.20 (*)
│   │   │       ├── quote v1.0.7 (*)
│   │   │       └── syn v1.0.40 (*)
│   │   └── pin-utils v0.1.0
│   ├── lazy_static v1.4.0
│   ├── libc v0.2.76
│   ├── mio v0.7.0
│   │   ├── libc v0.2.76
│   │   └── log v0.4.11
│   │       └── cfg-if v0.1.10
│   ├── parking_lot v0.10.2
│   │   ├── lock_api v0.3.4
│   │   │   └── scopeguard v1.1.0
│   │   └── parking_lot_core v0.7.2
│   │       ├── cfg-if v0.1.10
│   │       ├── libc v0.2.76
│   │       └── smallvec v1.4.2
│   └── signal-hook v0.1.16
│       ├── libc v0.2.76
│       ├── mio v0.7.0 (*)
│       └── signal-hook-registry v1.2.1
│           ├── arc-swap v0.4.7
│           └── libc v0.2.76
```

After:
```
crossterm
├── bitflags v1.2.1
├── futures-core v0.3.5
├── lazy_static v1.4.0
├── libc v0.2.76
├── mio v0.7.0
│   ├── libc v0.2.76
│   └── log v0.4.11
│       └── cfg-if v0.1.10
├── parking_lot v0.10.2
│   ├── lock_api v0.3.4
│   │   └── scopeguard v1.1.0
│   └── parking_lot_core v0.7.2
│       ├── cfg-if v0.1.10
│       ├── libc v0.2.76
│       └── smallvec v1.4.2
└── signal-hook v0.1.16
    ├── libc v0.2.76
    ├── mio v0.7.0 (*)
    └── signal-hook-registry v1.2.1
        ├── arc-swap v0.4.7
        └── libc v0.2.76
```

Similar to #474 but it cuts down the dependencies even further because futures-lite still depends on pin-project (and also futures-core) which is the heavy one, pulling in syn.