### PR TITLE
Fix azerty keyboard handling for windows

### DIFF
--- a/src/event/sys/windows/parse.rs
+++ b/src/event/sys/windows/parse.rs
@@ -79,19 +79,16 @@ fn parse_key_event_record(key_event: &KeyEventRecord) -> Option<KeyEvent> {
             let character_raw = key_event.u_char;
 
             if character_raw < 255 {
+                // Invalid character
+                if character_raw == 0 {
+                    return None;
+                }
+
                 let mut character = character_raw as u8 as char;
 
-                if modifiers.contains(KeyModifiers::ALT) {
-                    // If the ALT key is held down, pressing the A key produces ALT+A, which the system does not treat as a character at all, but rather as a system command.
-                    // The pressed command is stored in `virtual_key_code`.
-                    let command = key_event.virtual_key_code as u8 as char;
-
-                    if command.is_alphabetic() {
-                        character = command;
-                    } else {
-                        return None;
-                    }
-                } else if modifiers.contains(KeyModifiers::CONTROL) {
+                if modifiers.contains(KeyModifiers::CONTROL)
+                    && !modifiers.contains(KeyModifiers::ALT)
+                {
                     // we need to do some parsing
                     character = match character_raw as u8 {
                         c @ b'\x01'..=b'\x1A' => (c as u8 - 0x1 + b'a') as char,


### PR DESCRIPTION
Fix https://github.com/crossterm-rs/crossterm/issues/359

This pr adresses 2 issues:

1- Ignore invalid keys (for example pressing numpad lock, adds a space instead of doing nothing)
2- Accept (nums + alt) key combination by removing the early return, On windows at least on my testing the whole `if modifiers.contains(alt_key)` block is not needed, I added a comment for now till things becomes clear


I should note that on  my testing on azerty windows, I noticed that the left alt key is different from the right one:

- The right alt key is the important one , it returns `KeyModifiers::CONTROL |KeyModifiers::ALT`
- The left alt key (I don't know what this is used for, it doesn't do anything as far as I know on windows), it returns `KeyModifers::ALT`

edit: turns out its windows way of handling [AltGr](https://en.wikipedia.org/wiki/AltGr_key)