### PR TITLE
Expose supports_ansi function

### DIFF
--- a/src/ansi_support.rs
+++ b/src/ansi_support.rs
@@ -50,6 +50,7 @@ lazy_static! {
     };
 }
 
+/// Checks if the current terminal supports ansi escape sequences
 pub fn supports_ansi() -> bool {
     *SUPPORTS_ANSI_ESCAPE_CODES
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -250,7 +250,8 @@ pub mod tty;
 
 mod ansi;
 #[cfg(windows)]
-pub(crate) mod ansi_support;
+/// A module that exposes one function to check if the current terminal supports ansi sequences.
+pub mod ansi_support;
 mod command;
 mod error;
 pub(crate) mod macros;


### PR DESCRIPTION
This is a useful function, I can only argue about my own use case though:

Calling , from rust code, binaries that have a `--color` flag, its useful to know if the terminal supports ansi or no, to disable the flag if it doesn't (or even handling it by parsing  ansi to winapi) , since most of the time its ansi coloring (cargo for example)