### PR TITLE
Fix panic when only styling text and redirecting stdout

### DIFF
--- a/src/style/sys/windows.rs
+++ b/src/style/sys/windows.rs
@@ -70,10 +70,10 @@ pub(crate) fn set_background_color(bg_color: Color) -> Result<()> {
 }
 
 pub(crate) fn reset() -> Result<()> {
-    let original_color = original_console_color();
-
-    Console::from(Handle::new(HandleType::CurrentOutputHandle)?)
-        .set_text_attribute(original_color)?;
+    if let Some(original_color) = *ORIGINAL_CONSOLE_COLOR.lock().unwrap() {
+        Console::from(Handle::new(HandleType::CurrentOutputHandle)?)
+            .set_text_attribute(original_color)?;
+    }
 
     Ok(())
 }


### PR DESCRIPTION
**Reproduction Steps**

Create an application that first sets the style and not the colour:

```rust
fn main() {
    use crossterm::style::Styler;
    println!("{}", "Hello, world!".bold());
}
```

Then run with powershell on windows like so `$(cargo run)`.

**Backtrace**

```
thread 'main' panicked at 'Initial console color not set', C:\Users\david\.cargo\registry\src\github.com-1ecc6299db9ec823\crossterm-0.18.0\src\style\sys\windows.rs:100:10
stack backtrace:
   0: std::panicking::begin_panic_handler
             at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39\/library\std\src\panicking.rs:475
   1: core::panicking::panic_fmt
             at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39\/library\core\src\panicking.rs:85
   2: core::option::expect_failed
             at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39\/library\core\src\option.rs:1213
   3: core::option::Option<u16>::expect<u16>
             at C:\Users\david\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\core\src\option.rs:333
   4: crossterm::style::sys::windows::original_console_color
             at C:\Users\david\.cargo\registry\src\github.com-1ecc6299db9ec823\crossterm-0.18.0\src\style\sys\windows.rs:97
   5: crossterm::style::sys::windows::reset
             at C:\Users\david\.cargo\registry\src\github.com-1ecc6299db9ec823\crossterm-0.18.0\src\style\sys\windows.rs:73
   6: crossterm::style::{{impl}}::execute_winapi<closure-9>
             at C:\Users\david\.cargo\registry\src\github.com-1ecc6299db9ec823\crossterm-0.18.0\src\style.rs:416
   7: crossterm::style::styled_content::{{impl}}::fmt<str*>
             at C:\Users\david\.cargo\registry\src\github.com-1ecc6299db9ec823\crossterm-0.18.0\src\style\styled_content.rs:120
   8: core::fmt::write
             at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39\/library\core\src\fmt\mod.rs:1082
   9: std::io::Write::write_fmt
             at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39\/library\std\src\io\mod.rs:1514
  10: std::io::stdio::{{impl}}::write_fmt
             at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39\/library\std\src\io\stdio.rs:606
  11: std::io::stdio::print_to::{{closure}}
             at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39\/library\std\src\io\stdio.rs:890
  12: std::thread::local::LocalKey::try_with
             at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39\/library\std\src\thread\local.rs:265
  13: std::io::stdio::print_to
             at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39\/library\std\src\io\stdio.rs:879
  14: std::io::stdio::_print
             at /rustc/18bf6b4f01a6feaf7259ba7cdae58031af1b7b39\/library\std\src\io\stdio.rs:907
  15: crossterm_bug_repro::main
             at .\src\main.rs:3
  16: core::ops::function::FnOnce::call_once<fn(),tuple<>>
             at C:\Users\david\.rustup\toolchains\stable-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\core\src\ops\function.rs:227
```