### PR TITLE
Add support for any event tracking

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -285,7 +285,7 @@ pub enum Event {
 /// ## Mouse Buttons
 ///
 /// Some platforms/terminals do not report mouse button for the
-/// `MouseEvent::Up` and `MouseEvent::Drag` events. `MouseButton::Left`
+/// `MouseEventKind::Up` and `MouseEventKind::Drag` events. `MouseButton::Left`
 /// is returned if we don't know which button was used.
 ///
 /// ## Key Modifiers
@@ -295,27 +295,42 @@ pub enum Event {
 /// `Ctrl` + left mouse button click as a right mouse button click.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, PartialOrd, PartialEq, Eq, Clone, Copy, Hash)]
-pub enum MouseEvent {
-    /// Pressed mouse button.
-    ///
-    /// Contains mouse button, pressed pointer location (column, row), and additional key modifiers.
-    Down(MouseButton, u16, u16, KeyModifiers),
-    /// Released mouse button.
-    ///
-    /// Contains mouse button, released pointer location (column, row), and additional key modifiers.
-    Up(MouseButton, u16, u16, KeyModifiers),
-    /// Moved mouse pointer while pressing a mouse button.
-    ///
-    /// Contains the pressed mouse button, released pointer location (column, row), and additional key modifiers.
-    Drag(MouseButton, u16, u16, KeyModifiers),
+pub struct MouseEvent {
+    /// The kind of mouse event that was caused.
+    pub kind: MouseEventKind,
+    /// The column that the event occurred on.
+    pub column: u16,
+    /// The row that the event occurred on.
+    pub row: u16,
+    /// The key modifiers active when the event occurred.
+    pub modifiers: KeyModifiers,
+}
+
+/// A kind of mouse event.
+///
+/// # Platform-specific Notes
+///
+/// ## Mouse Buttons
+///
+/// Some platforms/terminals do not report mouse button for the
+/// `MouseEventKind::Up` and `MouseEventKind::Drag` events. `MouseButton::Left`
+/// is returned if we don't know which button was used.
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, PartialOrd, PartialEq, Eq, Clone, Copy, Hash)]
+pub enum MouseEventKind {
+    /// Pressed mouse button. Contains the button that was pressed.
+    Down(MouseButton),
+    /// Released mouse button. Contains the button that was released.
+    Up(MouseButton),
+    /// Moved mouse pointer while pressing a mouse button. Contains that button that was held while
+    /// the mouse was being moved.
+    Drag(MouseButton),
+    /// Moved mouse pointer while not pressing a mouse button.
+    Moved,
     /// Scrolled mouse wheel downwards (towards the user).
-    ///
-    /// Contains the scroll location (column, row), and additional key modifiers.
-    ScrollDown(u16, u16, KeyModifiers),
+    ScrollDown,
     /// Scrolled mouse wheel upwards (away from the user).
-    ///
-    /// Contains the scroll location (column, row), and additional key modifiers.
-    ScrollUp(u16, u16, KeyModifiers),
+    ScrollUp,
 }
 
 /// Represents a mouse button.

--- a/src/event.rs
+++ b/src/event.rs
@@ -306,7 +306,7 @@ pub struct MouseEvent {
     pub modifiers: KeyModifiers,
 }
 
-/// A kind of mouse event.
+/// A mouse event kind.
 ///
 /// # Platform-specific Notes
 ///
@@ -322,10 +322,9 @@ pub enum MouseEventKind {
     Down(MouseButton),
     /// Released mouse button. Contains the button that was released.
     Up(MouseButton),
-    /// Moved mouse pointer while pressing a mouse button. Contains that button that was held while
-    /// the mouse was being moved.
+    /// Moved the mouse cursor while pressing the contained mouse button.
     Drag(MouseButton),
-    /// Moved mouse pointer while not pressing a mouse button.
+    /// Moved the mouse cursor while not pressing a mouse button.
     Moved,
     /// Scrolled mouse wheel downwards (towards the user).
     ScrollDown,

--- a/src/event/ansi.rs
+++ b/src/event/ansi.rs
@@ -3,15 +3,23 @@
 use crate::csi;
 
 pub(crate) const ENABLE_MOUSE_MODE_CSI_SEQUENCE: &str = concat!(
+    // Normal tracking: Send mouse X & Y on button press and release
     csi!("?1000h"),
+    // Button-event tracking: Report button motion events (dragging)
     csi!("?1002h"),
+    // Any-event tracking: Report all motion events
+    csi!("?1003h"),
+    // RXVT mouse mode: Allows mouse coordinates of >223
     csi!("?1015h"),
-    csi!("?1006h")
+    // SGR mouse mode: Allows mouse coordinates of >223, preferred over RXVT mode
+    csi!("?1006h"),
 );
 
 pub(crate) const DISABLE_MOUSE_MODE_CSI_SEQUENCE: &str = concat!(
+    // The above, in reverse order.
     csi!("?1006l"),
     csi!("?1015l"),
+    csi!("?1003l"),
     csi!("?1002l"),
-    csi!("?1000l")
+    csi!("?1000l"),
 );

--- a/src/event/sys/unix/parse.rs
+++ b/src/event/sys/unix/parse.rs
@@ -351,6 +351,12 @@ pub(crate) fn parse_csi_sgr_mouse(buffer: &[u8]) -> Result<Option<InternalEvent>
     let cx = next_parsed::<u16>(&mut split)? - 1;
     let cy = next_parsed::<u16>(&mut split)? - 1;
 
+    // When button 3 in Cb is used to represent mouse release, you can't tell which button was
+    // released. SGR mode solves this by having the sequence end with a lowercase m if it's a
+    // button release and an uppercase M if it's a buton press.
+    //
+    // We've already checked that the last character is a lowercase or uppercase M at the start of
+    // this function, so we just need one if.
     let kind = if buffer.last() == Some(&b'm') {
         match kind {
             MouseEventKind::Down(button) => MouseEventKind::Up(button),

--- a/src/event/sys/windows/poll.rs
+++ b/src/event/sys/windows/poll.rs
@@ -22,15 +22,10 @@ pub(crate) struct WinApiPoll {
 }
 
 impl WinApiPoll {
-    #[cfg(not(feature = "event-stream"))]
-    pub(crate) fn new() -> Result<WinApiPoll> {
-        Ok(WinApiPoll {})
-    }
-
-    #[cfg(feature = "event-stream")]
     pub(crate) fn new() -> Result<WinApiPoll> {
         Ok(WinApiPoll {
-            waker: Waker::new()?,
+            #[cfg(feature = "event-stream")]
+            waker: Waker::new()?
         })
     }
 }

--- a/src/event/sys/windows/poll.rs
+++ b/src/event/sys/windows/poll.rs
@@ -25,7 +25,7 @@ impl WinApiPoll {
     pub(crate) fn new() -> Result<WinApiPoll> {
         Ok(WinApiPoll {
             #[cfg(feature = "event-stream")]
-            waker: Waker::new()?
+            waker: Waker::new()?,
         })
     }
 }


### PR DESCRIPTION
This adds support for any-event tracking, where all mouse movements are reported even if no buttons are held down. I used Xterm's [ctlseqs](https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h2-Mouse-Tracking) as reference, and I have tested this on URXVT, xterm, st and alacritty in both normal mode and SGR mode, and it seems to work fine.