### PR TITLE
Fix InternalEventReader::poll timeout computation

### DIFF
--- a/src/event/read.rs
+++ b/src/event/read.rs
@@ -65,7 +65,7 @@ impl InternalEventReader {
         let poll_timeout = PollTimeout::new(timeout);
 
         loop {
-            let maybe_event = match event_source.try_read(timeout) {
+            let maybe_event = match event_source.try_read(poll_timeout.leftover()) {
                 Ok(None) => None,
                 Ok(Some(event)) => {
                     if filter.eval(&event) {


### PR DESCRIPTION
**Describe the bug**

The poll function does not respect the passed Duration.
Sometime the polling time is doubled in **InternalEventReader::poll** when
**event_source.try_read** returns **None** and **poll_timeout.elapsed()** returns **false**

**poll_timeout.leftover()** must be used insted of **timeout**


**To Reproduce**

Steps to reproduce the behavior:
1. run the event poll example
  cargo run --example  event-poll-read
  
2. let the program run without doing anything

**Expected behavior**
The '.' characters should be displayed every seconds


**OS**
 - Linux Ubuntu 20.10

**Terminal/Console**
 - Konsole
