### PR TITLE
Disable the mouse capture in the demo to allow scrolling to work

### DIFF
--- a/examples/interactive-demo/src/test/event.rs
+++ b/examples/interactive-demo/src/test/event.rs
@@ -2,7 +2,7 @@
 
 use crossterm::{
     cursor::position,
-    event::{read, EnableMouseCapture, Event, KeyCode},
+    event::{read, DisableMouseCapture, EnableMouseCapture, Event, KeyCode},
     execute, Result,
 };
 use std::io::Write;
@@ -27,6 +27,8 @@ where
             break;
         }
     }
+
+    execute!(w, DisableMouseCapture)?;
 
     Ok(())
 }


### PR DESCRIPTION
The demo currently doesn't DisableMouseCapture if one runs the Event test. This stops my terminal from being able to scroll properly after the demo exits. This pull request simply DisableMouseCapture right before the test exits.