### PR TITLE
Add support for combining some modifier keys

### DIFF
--- a/src/event/sys/unix/parse.rs
+++ b/src/event/sys/unix/parse.rs
@@ -499,7 +499,6 @@ mod tests {
         assert_eq!(
             parse_event(b"\x1BH", false).unwrap(),
             Some(InternalEvent::Event(Event::Key(KeyEvent::new(
-                //
                 KeyCode::Char('H'),
                 KeyModifiers::ALT | KeyModifiers::SHIFT
             )))),


### PR DESCRIPTION
Partially helps with #515 but doesn't completely solve the issue, as it only really helps with the alt key and only on Unix systems. Getting ctrl+shift might be difficult though, as from my testing combining those keys outputs the same values to the buffer as just ctrl.