### PR TITLE
Simplify ansi_support

### DIFF
--- a/src/ansi_support.rs
+++ b/src/ansi_support.rs
@@ -5,29 +5,23 @@ use lazy_static::lazy_static;
 
 use crate::Result;
 
-/// Toggle virtual terminal processing.
+/// Enable virtual terminal processing.
 ///
-/// This method attempts to toggle virtual terminal processing for this
-/// console. If there was a problem toggling it, then an error returned.
-/// On success, the caller may assume that toggling it was successful.
+/// This method attempts to enable virtual terminal processing for this
+/// console. If there was a problem enabling it, then an error returned.
+/// On success, the caller may assume that enabling it was successful.
 ///
 /// When virtual terminal processing is enabled, characters emitted to the
 /// console are parsed for VT100 and similar control character sequences
 /// that control color and other similar operations.
-pub(crate) fn set_virtual_terminal_processing(yes: bool) -> Result<()> {
+fn enable_vt_processing() -> Result<()> {
     let mask = ENABLE_VIRTUAL_TERMINAL_PROCESSING;
 
     let console_mode = ConsoleMode::from(Handle::current_out_handle()?);
     let old_mode = console_mode.mode()?;
 
-    let new_mode = if yes {
-        old_mode | mask
-    } else {
-        old_mode & !mask
-    };
-
-    if old_mode != new_mode {
-        console_mode.set_mode(new_mode)?;
+    if old_mode & mask == 0 {
+        console_mode.set_mode(old_mode | mask)?;
     }
 
     Ok(())
@@ -35,46 +29,11 @@ pub(crate) fn set_virtual_terminal_processing(yes: bool) -> Result<()> {
 
 lazy_static! {
     static ref SUPPORTS_ANSI_ESCAPE_CODES: bool = {
-        // Some terminals on windows like GitBash can't use WinaApi calls directly
-        // so when we try to enable the ANSI-flag for windows this won't work.
-        // Because of that we should check first if the TERM-variable is set
-        // and see if the current terminal is a terminal who does support ANSI.
-        if is_specific_term() {
-            true
-        } else {
-            // if it is not listed we should try with WinApi to check if we do support ANSI-codes.
-            set_virtual_terminal_processing(true)
-                .map(|_| true)
-                .unwrap_or(false)
-        }
+        std::env::var("TERM").map_or(false, |term| term != "dumb") || enable_vt_processing().is_ok()
     };
 }
 
 /// Checks if the current terminal supports ansi escape sequences
 pub fn supports_ansi() -> bool {
     *SUPPORTS_ANSI_ESCAPE_CODES
-}
-
-// Checks if the 'TERM' environment variable is set to check if the terminal supports ANSI-codes.
-// I got the list of terminals from here: https://github.com/keqingrong/supports-ansi/blob/master/index.js
-fn is_specific_term() -> bool {
-    const TERMS: [&str; 15] = [
-        "xterm",  // xterm, PuTTY, Mintty
-        "rxvt",   // RXVT
-        "eterm",  // Eterm
-        "screen", // GNU screen, tmux
-        "tmux",   // tmux
-        "vt100", "vt102", "vt220", "vt320",   // DEC VT series
-        "ansi",    // ANSI
-        "scoansi", // SCO ANSI
-        "cygwin",  // Cygwin, MinGW
-        "linux",   // Linux console
-        "konsole", // Konsole
-        "bvterm",  // Bitvise SSH Client
-    ];
-
-    match std::env::var("TERM") {
-        Ok(val) => val != "dumb" || TERMS.contains(&val.as_str()),
-        Err(_) => false,
-    }
 }

--- a/src/ansi_support.rs
+++ b/src/ansi_support.rs
@@ -29,6 +29,10 @@ fn enable_vt_processing() -> Result<()> {
 
 lazy_static! {
     static ref SUPPORTS_ANSI_ESCAPE_CODES: bool = {
+        // Some terminals on Windows like GitBash can't use WinAPI calls directly
+        // so when we try to enable the ANSI-flag for Windows this won't work.
+        // Because of that we should check first if the TERM-variable is set
+        // and see if the current terminal is a terminal who does support ANSI.
         std::env::var("TERM").map_or(false, |term| term != "dumb") || enable_vt_processing().is_ok()
     };
 }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -387,8 +387,6 @@ mod tests {
     #[test]
     #[ignore]
     fn test_resize_ansi() {
-        try_enable_ansi();
-
         let (width, height) = size().unwrap();
 
         execute!(stdout(), SetSize(35, 35)).unwrap();
@@ -405,22 +403,5 @@ mod tests {
         thread::sleep(time::Duration::from_millis(30));
 
         assert_eq!((width, height), size().unwrap());
-    }
-
-    fn try_enable_ansi() -> bool {
-        #[cfg(windows)]
-        {
-            if cfg!(target_os = "windows") {
-                use crate::ansi_support::set_virtual_terminal_processing;
-
-                // if it is not listed we should try with WinApi to check if we do support ANSI-codes.
-                match set_virtual_terminal_processing(true) {
-                    Ok(_) => return true,
-                    Err(_) => return false,
-                }
-            }
-        }
-
-        true
     }
 }


### PR DESCRIPTION
This greatly simplifies the `ansi_support` module.

- Instead of having a function to toggle vt processing it can only enable it, since that's all we do in Crossterm.
- Checking for a specific term is completely redundant since all that matters is that `$TERM` isn't `dumb`.
- It isn't necessary to attempt to enable ANSI support in terminal.rs since it's done automatically whenever a command is called.