### PR TITLE
Fix clippy warnings

### DIFF
--- a/examples/event-read.rs
+++ b/examples/event-read.rs
@@ -50,13 +50,9 @@ fn print_events() -> Result<()> {
 fn flush_resize_events(event: Event) -> ((u16, u16), (u16, u16)) {
     if let Event::Resize(x, y) = event {
         let mut last_resize = (x, y);
-        loop {
-            if let Ok(true) = poll(Duration::from_millis(50)) {
-                if let Ok(Event::Resize(x, y)) = read() {
-                    last_resize = (x, y);
-                }
-            } else {
-                break;
+        while let Ok(true) = poll(Duration::from_millis(50)) {
+            if let Ok(Event::Resize(x, y)) = read() {
+                last_resize = (x, y);
             }
         }
 

--- a/src/event/sys/unix/parse.rs
+++ b/src/event/sys/unix/parse.rs
@@ -156,7 +156,7 @@ pub(crate) fn parse_csi(buffer: &[u8]) -> Result<Option<InternalEvent>> {
                 // The final byte of a CSI sequence can be in the range 64-126, so
                 // let's keep reading anything else.
                 let last_byte = *buffer.last().unwrap();
-                if last_byte < 64 || last_byte > 126 {
+                if !(64..=126).contains(&last_byte) {
                     None
                 } else {
                     match buffer[buffer.len() - 1] {

--- a/src/terminal/sys/unix.rs
+++ b/src/terminal/sys/unix.rs
@@ -87,20 +87,17 @@ pub(crate) fn disable_raw_mode() -> Result<()> {
 ///
 /// The arg should be "cols" or "lines"
 fn tput_value(arg: &str) -> Option<u16> {
-    match process::Command::new("tput").arg(arg).output() {
-        Ok(process::Output { stdout, .. }) => {
-            let value = stdout
-                .iter()
-                .map(|&b| b as u16)
-                .take_while(|&b| b >= 48 && b <= 58)
-                .fold(0, |v, b| v * 10 + (b - 48));
-            if value > 0 {
-                Some(value)
-            } else {
-                None
-            }
-        }
-        _ => None,
+    let output = process::Command::new("tput").arg(arg).output().ok()?;
+    let value = output
+        .stdout
+        .into_iter()
+        .filter_map(|b| char::from(b).to_digit(10))
+        .fold(0, |v, n| v * 10 + n as u16);
+
+    if value > 0 {
+        Some(value)
+    } else {
+        None
     }
 }
 


### PR DESCRIPTION
Rust 1.46 broke CI with the new `manual_range_contains` lint, so I fixed it up and CI should pass again.