### PR TITLE
Remove extra Clone bounds in the style module

### DIFF
--- a/src/style.rs
+++ b/src/style.rs
@@ -153,10 +153,7 @@ mod types;
 ///
 /// println!("{}", styled_content);
 /// ```
-pub fn style<'a, D: 'a>(val: D) -> StyledContent<D>
-where
-    D: Display + Clone,
-{
+pub fn style<D: Display>(val: D) -> StyledContent<D> {
     ContentStyle::new().apply(val)
 }
 

--- a/src/style/styled_content.rs
+++ b/src/style/styled_content.rs
@@ -132,11 +132,11 @@ impl<D: Display> Display for StyledContent<D> {
     }
 }
 
-impl<D: Display + Clone> Colorize<D> for StyledContent<D> {
+impl<D: Display> Colorize<D> for StyledContent<D> {
     impl_colorize_callback!(def_color_generic!(()));
 }
 
-impl<D: Display + Clone> Styler<D> for StyledContent<D> {
+impl<D: Display> Styler<D> for StyledContent<D> {
     impl_styler_callback!(def_attr_generic!(()));
 }
 

--- a/src/style/traits.rs
+++ b/src/style/traits.rs
@@ -17,7 +17,7 @@ use super::StyledContent;
 /// let styled_text = "Red foreground color on blue background.".red().on_blue();
 /// println!("{}", styled_text);
 /// ```
-pub trait Colorize<D: Display + Clone> {
+pub trait Colorize<D: Display> {
     fn black(self) -> StyledContent<D>;
     fn dark_grey(self) -> StyledContent<D>;
     fn red(self) -> StyledContent<D>;
@@ -66,7 +66,7 @@ pub trait Colorize<D: Display + Clone> {
 /// println!("{}", "Underlined text".underlined());
 /// println!("{}", "Negative text".negative());
 /// ```
-pub trait Styler<D: Display + Clone> {
+pub trait Styler<D: Display> {
     fn reset(self) -> StyledContent<D>;
     fn bold(self) -> StyledContent<D>;
     fn underlined(self) -> StyledContent<D>;


### PR DESCRIPTION
Since the print-like commands no longer require `Clone`, these functions don't need to either.