### PR TITLE
fixed doc-comment in event.rs

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -442,11 +442,11 @@ pub enum KeyCode {
     Insert,
     /// F key.
     ///
-    /// `KeyEvent::F(1)` represents F1 key, etc.
+    /// `KeyCode::F(1)` represents F1 key, etc.
     F(u8),
     /// A character.
     ///
-    /// `KeyEvent::Char('c')` represents `c` character, etc.
+    /// `KeyCode::Char('c')` represents `c` character, etc.
     Char(char),
     /// Null.
     Null,


### PR DESCRIPTION
Updated two doc comments inside `event::KeyCode`.  

Using `KeyEvent::Char(...)` only gives me a compiler error; `KeyCode::Char(...)` is correct.