### PR TITLE
refactor: fix clippy warnings

### DIFF
--- a/src/event/source/unix.rs
+++ b/src/event/source/unix.rs
@@ -41,7 +41,7 @@ pub(crate) struct UnixInternalEventSource {
 
 impl UnixInternalEventSource {
     pub fn new() -> Result<Self> {
-        Ok(UnixInternalEventSource::from_file_descriptor(tty_fd()?)?)
+        UnixInternalEventSource::from_file_descriptor(tty_fd()?)
     }
 
     pub(crate) fn from_file_descriptor(input_fd: FileDesc) -> Result<Self> {

--- a/src/event/source/windows.rs
+++ b/src/event/source/windows.rs
@@ -23,7 +23,11 @@ impl WindowsEventSource {
         let console = Console::from(Handle::current_in_handle()?);
         Ok(WindowsEventSource {
             console,
+            
+            #[cfg(not(feature = "event-stream"))]
             poll: WinApiPoll::new(),
+            #[cfg(feature = "event-stream")]
+            poll: WinApiPoll::new()?,
         })
     }
 }

--- a/src/event/source/windows.rs
+++ b/src/event/source/windows.rs
@@ -23,7 +23,7 @@ impl WindowsEventSource {
         let console = Console::from(Handle::current_in_handle()?);
         Ok(WindowsEventSource {
             console,
-            poll: WinApiPoll::new()?,
+            poll: WinApiPoll::new(),
         })
     }
 }
@@ -37,8 +37,8 @@ impl EventSource for WindowsEventSource {
                 let number = self.console.number_of_console_input_events()?;
                 if event_ready && number != 0 {
                     let event = match self.console.read_single_input_event()? {
-                        InputRecord::KeyEvent(record) => handle_key_event(record)?,
-                        InputRecord::MouseEvent(record) => handle_mouse_event(record)?,
+                        InputRecord::KeyEvent(record) => handle_key_event(record),
+                        InputRecord::MouseEvent(record) => handle_mouse_event(record),
                         InputRecord::WindowBufferSizeEvent(record) => {
                             Some(Event::Resize(record.size.x as u16, record.size.y as u16))
                         }

--- a/src/event/source/windows.rs
+++ b/src/event/source/windows.rs
@@ -23,7 +23,7 @@ impl WindowsEventSource {
         let console = Console::from(Handle::current_in_handle()?);
         Ok(WindowsEventSource {
             console,
-            
+
             #[cfg(not(feature = "event-stream"))]
             poll: WinApiPoll::new(),
             #[cfg(feature = "event-stream")]

--- a/src/event/sys/windows/parse.rs
+++ b/src/event/sys/windows/parse.rs
@@ -14,21 +14,22 @@ use crate::{
     Result,
 };
 
-pub(crate) fn handle_mouse_event(mouse_event: MouseEvent) -> Result<Option<Event>> {
+pub(crate) fn handle_mouse_event(mouse_event: MouseEvent) -> Option<Event> {
     if let Ok(Some(event)) = parse_mouse_event_record(&mouse_event) {
-        return Ok(Some(Event::Mouse(event)));
+        return Some(Event::Mouse(event));
     }
-    Ok(None)
+
+    None
 }
 
-pub(crate) fn handle_key_event(key_event: KeyEventRecord) -> Result<Option<Event>> {
+pub(crate) fn handle_key_event(key_event: KeyEventRecord) -> Option<Event> {
     if key_event.key_down {
         if let Some(event) = parse_key_event_record(&key_event) {
-            return Ok(Some(Event::Key(event)));
+            return Some(Event::Key(event));
         }
     }
 
-    Ok(None)
+    None
 }
 
 impl From<ControlKeyState> for KeyModifiers {

--- a/src/event/sys/windows/poll.rs
+++ b/src/event/sys/windows/poll.rs
@@ -22,11 +22,11 @@ pub(crate) struct WinApiPoll {
 }
 
 impl WinApiPoll {
-    pub(crate) fn new() -> Result<WinApiPoll> {
-        Ok(WinApiPoll {
+    pub(crate) fn new() -> WinApiPoll {
+        WinApiPoll {
             #[cfg(feature = "event-stream")]
             waker: Waker::new()?,
-        })
+        }
     }
 }
 

--- a/src/event/sys/windows/poll.rs
+++ b/src/event/sys/windows/poll.rs
@@ -22,11 +22,16 @@ pub(crate) struct WinApiPoll {
 }
 
 impl WinApiPoll {
+    #[cfg(not(feature = "event-stream"))]
     pub(crate) fn new() -> WinApiPoll {
-        WinApiPoll {
-            #[cfg(feature = "event-stream")]
+        WinApiPoll {}
+    }
+
+    #[cfg(feature = "event-stream")]
+    pub(crate) fn new() -> Result<WinApiPoll> {
+        Ok(WinApiPoll {
             waker: Waker::new()?,
-        }
+        })
     }
 }
 


### PR DESCRIPTION
All of the current PRs fail CI due to clippy failing on the main branch.
I fixed the errors that got returned. I had to change some internal
method signatures as some methods returned `Result<Option<T>>` but never
returned an error value, making the `Result` wrapping  unnecessary.