### PR TITLE
refactor: remove unneeded imports

### DIFF
--- a/examples/event-stream-async-std.rs
+++ b/examples/event-stream-async-std.rs
@@ -2,10 +2,7 @@
 //!
 //! cargo run --features="event-stream" --example event-stream-async-std
 
-use std::{
-    io::{stdout, Write},
-    time::Duration,
-};
+use std::{io::stdout, time::Duration};
 
 use futures::{future::FutureExt, select, StreamExt};
 use futures_timer::Delay;

--- a/examples/event-stream-tokio.rs
+++ b/examples/event-stream-tokio.rs
@@ -2,10 +2,7 @@
 //!
 //! cargo run --features="event-stream" --example event-stream-tokio
 
-use std::{
-    io::{stdout, Write},
-    time::Duration,
-};
+use std::{io::stdout, time::Duration};
 
 use futures::{future::FutureExt, select, StreamExt};
 use futures_timer::Delay;

--- a/src/event/stream.rs
+++ b/src/event/stream.rs
@@ -113,7 +113,9 @@ impl Stream for EventStream {
             Ok(false) => {
                 if !self
                     .stream_wake_task_executed
-                    .compare_and_swap(false, true, Ordering::SeqCst)
+                    .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+                    // https://github.com/rust-lang/rust/issues/80486#issuecomment-752244166
+                    .unwrap_or_else(|x| x)
                 {
                     let stream_waker = cx.waker().clone();
                     let stream_wake_task_executed = self.stream_wake_task_executed.clone();

--- a/src/event/sys/unix/waker.rs
+++ b/src/event/sys/unix/waker.rs
@@ -27,7 +27,7 @@ impl Waker {
             .lock()
             .unwrap()
             .wake()
-            .map_err(|e| ErrorKind::IoError(e))
+            .map_err(ErrorKind::IoError)
     }
 
     /// Resets the state so the same waker can be reused.

--- a/src/event/sys/unix/waker.rs
+++ b/src/event/sys/unix/waker.rs
@@ -33,6 +33,7 @@ impl Waker {
     /// Resets the state so the same waker can be reused.
     ///
     /// This function is not impl
+    #[allow(dead_code, clippy::clippy::unnecessary_wraps)]
     pub(crate) fn reset(&self) -> Result<()> {
         Ok(())
     }


### PR DESCRIPTION
Some warnings show up in the CI logs (click on the `Files changed` tab of an open PR, for example #551, and scrolling down a little bit).