### PR TITLE
Use io::Error for public error type

### DIFF
--- a/src/cursor/sys/unix.rs
+++ b/src/cursor/sys/unix.rs
@@ -46,8 +46,7 @@ fn read_position_raw() -> Result<(u16, u16)> {
                 return Err(Error::new(
                     ErrorKind::Other,
                     "The cursor position could not be read within a normal duration",
-                )
-                .into());
+                ));
             }
             Err(_) => {}
         }

--- a/src/cursor/sys/windows.rs
+++ b/src/cursor/sys/windows.rs
@@ -138,8 +138,7 @@ impl ScreenBufferCursor {
                     "Argument Out of Range Exception when setting cursor position to X: {}",
                     x
                 ),
-            )
-            .into());
+            ));
         }
 
         if y < 0 {
@@ -149,8 +148,7 @@ impl ScreenBufferCursor {
                     "Argument Out of Range Exception when setting cursor position to Y: {}",
                     y
                 ),
-            )
-            .into());
+            ));
         }
 
         let position = COORD { X: x, Y: y };
@@ -160,7 +158,7 @@ impl ScreenBufferCursor {
                 **self.screen_buffer.handle(),
                 position,
             )) {
-                return Err(io::Error::last_os_error().into());
+                return Err(io::Error::last_os_error());
             }
         }
         Ok(())
@@ -177,7 +175,7 @@ impl ScreenBufferCursor {
                 **self.screen_buffer.handle(),
                 &cursor_info,
             )) {
-                return Err(io::Error::last_os_error().into());
+                return Err(io::Error::last_os_error());
             }
         }
         Ok(())

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,50 +1,8 @@
 //! Module containing error handling logic.
 
-use std::{
-    fmt::{self, Display, Formatter},
-    io,
-};
-
-use crate::impl_from;
+use std::io;
 
 /// The `crossterm` result type.
 pub type Result<T> = std::result::Result<T, ErrorKind>;
 
-/// Wrapper for all errors that can occur in `crossterm`.
-#[derive(Debug)]
-#[non_exhaustive]
-pub enum ErrorKind {
-    IoError(io::Error),
-    FmtError(fmt::Error),
-    Utf8Error(std::string::FromUtf8Error),
-    ParseIntError(std::num::ParseIntError),
-    ResizingTerminalFailure(String),
-    SettingTerminalTitleFailure,
-}
-
-impl std::error::Error for ErrorKind {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            ErrorKind::IoError(e) => Some(e),
-            ErrorKind::FmtError(e) => Some(e),
-            ErrorKind::Utf8Error(e) => Some(e),
-            ErrorKind::ParseIntError(e) => Some(e),
-            _ => None,
-        }
-    }
-}
-
-impl Display for ErrorKind {
-    fn fmt(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
-        match *self {
-            ErrorKind::IoError(_) => write!(fmt, "IO-error occurred"),
-            ErrorKind::ResizingTerminalFailure(_) => write!(fmt, "Cannot resize the terminal"),
-            _ => write!(fmt, "Some error has occurred"),
-        }
-    }
-}
-
-impl_from!(io::Error, ErrorKind::IoError);
-impl_from!(fmt::Error, ErrorKind::FmtError);
-impl_from!(std::string::FromUtf8Error, ErrorKind::Utf8Error);
-impl_from!(std::num::ParseIntError, ErrorKind::ParseIntError);
+pub type ErrorKind = io::Error;

--- a/src/event/source/unix.rs
+++ b/src/event/source/unix.rs
@@ -3,7 +3,7 @@ use std::{collections::VecDeque, io, time::Duration};
 use mio::{unix::SourceFd, Events, Interest, Poll, Token};
 use signal_hook::iterator::Signals;
 
-use crate::{ErrorKind, Result};
+use crate::Result;
 
 #[cfg(feature = "event-stream")]
 use super::super::sys::Waker;
@@ -41,7 +41,7 @@ pub(crate) struct UnixInternalEventSource {
 
 impl UnixInternalEventSource {
     pub fn new() -> Result<Self> {
-        Ok(UnixInternalEventSource::from_file_descriptor(tty_fd()?)?)
+        UnixInternalEventSource::from_file_descriptor(tty_fd()?)
     }
 
     pub(crate) fn from_file_descriptor(input_fd: FileDesc) -> Result<Self> {
@@ -87,7 +87,7 @@ impl EventSource for UnixInternalEventSource {
                 if e.kind() == io::ErrorKind::Interrupted {
                     continue;
                 } else {
-                    return Err(ErrorKind::IoError(e));
+                    return Err(e);
                 }
             };
 
@@ -109,7 +109,7 @@ impl EventSource for UnixInternalEventSource {
                                         );
                                     }
                                 }
-                                Err(ErrorKind::IoError(e)) => {
+                                Err(e) => {
                                     // No more data to read at the moment. We will receive another event
                                     if e.kind() == io::ErrorKind::WouldBlock {
                                         break;
@@ -119,7 +119,6 @@ impl EventSource for UnixInternalEventSource {
                                         continue;
                                     }
                                 }
-                                Err(e) => return Err(e),
                             };
 
                             if let Some(event) = self.parser.next() {

--- a/src/event/sys/unix/file_descriptor.rs
+++ b/src/event/sys/unix/file_descriptor.rs
@@ -5,7 +5,7 @@ use std::{
 
 use libc::size_t;
 
-use crate::{ErrorKind, Result};
+use crate::Result;
 
 /// A file descriptor wrapper.
 ///
@@ -38,7 +38,7 @@ impl FileDesc {
         };
 
         if result < 0 {
-            Err(ErrorKind::IoError(io::Error::last_os_error()))
+            Err(io::Error::last_os_error())
         } else {
             Ok(result as usize)
         }

--- a/src/event/sys/unix/parse.rs
+++ b/src/event/sys/unix/parse.rs
@@ -20,10 +20,7 @@ use super::super::super::InternalEvent;
 //
 
 fn could_not_parse_event_error() -> ErrorKind {
-    ErrorKind::IoError(io::Error::new(
-        io::ErrorKind::Other,
-        "Could not parse an event.",
-    ))
+    io::Error::new(io::ErrorKind::Other, "Could not parse an event.")
 }
 
 pub(crate) fn parse_event(buffer: &[u8], input_available: bool) -> Result<Option<InternalEvent>> {

--- a/src/event/sys/windows/poll.rs
+++ b/src/event/sys/windows/poll.rs
@@ -69,12 +69,11 @@ impl WinApiPoll {
                 // timeout elapsed
                 Ok(None)
             }
-            WAIT_FAILED => Err(io::Error::last_os_error().into()),
+            WAIT_FAILED => Err(io::Error::last_os_error()),
             _ => Err(io::Error::new(
                 io::ErrorKind::Other,
                 "WaitForMultipleObjects returned unexpected result.",
-            )
-            .into()),
+            )),
         }
     }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -117,7 +117,7 @@ macro_rules! execute {
         // Queue each command, then flush
         $crate::queue!($writer $(, $command)*)
             .and_then(|()| {
-                ::std::io::Write::flush($writer.by_ref()).map_err($crate::ErrorKind::IoError)
+                ::std::io::Write::flush($writer.by_ref())
             })
     }}
 }

--- a/src/terminal/sys/unix.rs
+++ b/src/terminal/sys/unix.rs
@@ -10,7 +10,7 @@ use libc::{
 };
 use parking_lot::Mutex;
 
-use crate::error::{ErrorKind, Result};
+use crate::error::Result;
 use crate::event::sys::unix::file_descriptor::{tty_fd, FileDesc};
 
 // Some(Termios) -> we're in the raw mode and this is the previous mode
@@ -129,7 +129,7 @@ fn set_terminal_attr(fd: RawFd, termios: &Termios) -> Result<()> {
 
 fn wrap_with_result(result: i32) -> Result<()> {
     if result == -1 {
-        Err(ErrorKind::IoError(io::Error::last_os_error()))
+        Err(io::Error::last_os_error())
     } else {
         Ok(())
     }


### PR DESCRIPTION
This makes interoperation with the standard library much easier for users, which is especially useful given crossterm's low level APIs.

A custom error type is only useful if the context it provides outweighs its ergonomic burden, and in this case only the `ResizingTerminalFailure` and `SettingTerminalTitleFailure` variants were being used.

Do we have examples of these variants being used in dependent code? I can add them to the new representation if so.