### PR TITLE
[draft] Add Bracketed Paste Events

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -295,7 +295,7 @@ impl Command for DisableMouseCapture {
 
 /// Represents an event.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, PartialOrd, PartialEq, Eq, Clone, Copy, Hash)]
+#[derive(Debug, PartialOrd, PartialEq, Eq, Clone, Hash)]
 pub enum Event {
     /// A single key event with additional pressed modifiers.
     Key(KeyEvent),
@@ -304,6 +304,7 @@ pub enum Event {
     /// An resize event with new dimensions after resize (columns, rows).
     /// **Note** that resize events can be occur in batches.
     Resize(u16, u16),
+    PasteEvents(Vec<Event>),
 }
 
 /// Represents a mouse event.
@@ -465,4 +466,6 @@ pub(crate) enum InternalEvent {
     /// A cursor position (`col`, `row`).
     #[cfg(unix)]
     CursorPosition(u16, u16),
+    BracketedPasteStart,
+    BracketedPasteEnd,
 }

--- a/src/event/source/unix.rs
+++ b/src/event/source/unix.rs
@@ -130,12 +130,13 @@ impl EventSource for UnixInternalEventSource {
                                             return Ok(Some(InternalEvent::Event(
                                                 Event::PasteEvents(buffer.drain(..).collect()),
                                             )));
+                                        } else if let InternalEvent::Event(event) = event {
+                                            buffer.push(event);
                                         } else {
-                                            if let InternalEvent::Event(event) = event {
-                                                buffer.push(event);
-                                            } else {
-                                                unreachable!();
-                                            }
+                                            // Speculation: Events between BracketedPasteStart and
+                                            // BracketedPasteEnd are guarentteed to be
+                                            // InternalEvent::Event::Char
+                                            unreachable!();
                                         }
                                     }
                                 } else {

--- a/src/event/source/unix.rs
+++ b/src/event/source/unix.rs
@@ -123,7 +123,24 @@ impl EventSource for UnixInternalEventSource {
                             };
 
                             if let Some(event) = self.parser.next() {
-                                return Ok(Some(event));
+                                if event == InternalEvent::BracketedPasteStart {
+                                    let mut buffer = vec![];
+                                    while let Some(event) = self.parser.next() {
+                                        if event == InternalEvent::BracketedPasteEnd {
+                                            return Ok(Some(InternalEvent::Event(
+                                                Event::PasteEvents(buffer.drain(..).collect()),
+                                            )));
+                                        } else {
+                                            if let InternalEvent::Event(event) = event {
+                                                buffer.push(event);
+                                            } else {
+                                                unreachable!();
+                                            }
+                                        }
+                                    }
+                                } else {
+                                    return Ok(Some(event));
+                                }
                             }
                         }
                     }

--- a/src/event/sys/unix/parse.rs
+++ b/src/event/sys/unix/parse.rs
@@ -159,6 +159,14 @@ pub(crate) fn parse_csi(buffer: &[u8]) -> Result<Option<InternalEvent>> {
                 if !(64..=126).contains(&last_byte) {
                     None
                 } else {
+                    if &buffer[..6] == b"\x1b[200~" {
+                        // bracketed paste start
+                        return Ok(Some(InternalEvent::BracketedPasteStart));
+                    }
+                    if &buffer[..6] == b"\x1b[201~" {
+                        // bracketed paste end
+                        return Ok(Some(InternalEvent::BracketedPasteEnd));
+                    }
                     match buffer[buffer.len() - 1] {
                         b'M' => return parse_csi_rxvt_mouse(buffer),
                         b'~' => return parse_csi_special_key_code(buffer),

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -117,6 +117,36 @@ pub fn size() -> Result<(u16, u16)> {
     sys::size()
 }
 
+/// Enable  BracketedPaste mode
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EnableBracketPasteMode;
+
+impl Command for EnableBracketPasteMode {
+    fn write_ansi(&self, f: &mut impl fmt::Write) -> fmt::Result {
+        f.write_str(csi!("?2004h"))
+    }
+
+    #[cfg(windows)]
+    fn execute_winapi(&self, _writer: impl FnMut() -> Result<()>) -> Result<()> {
+        todo!();
+    }
+}
+
+/// Disable  BracketedPaste mode
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DisableBracketPasteMode;
+
+impl Command for DisableBracketPasteMode {
+    fn write_ansi(&self, f: &mut impl fmt::Write) -> fmt::Result {
+        f.write_str(csi!("?2004l"))
+    }
+
+    #[cfg(windows)]
+    fn execute_winapi(&self, _writer: impl FnMut() -> Result<()>) -> Result<()> {
+        todo!();
+    }
+}
+
 /// Disables line wrapping.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DisableLineWrap;


### PR DESCRIPTION
https://github.com/crossterm-rs/crossterm/issues/545

Couple of points:

- I can flatten  `PasteEvents(Vec<Event>)` to become `PasteEvent(String)`
- I'm not sure how to restore `Copy` bound to `Event`
- I think for winapi I should just stub it with Ok(())
- Is flushing events like this https://github.com/crossterm-rs/crossterm/compare/master...sigmaSd:add_brakceted_paste_mode?expand=1#diff-835dd5a0632e3b0d7b10539464274511152432fac2dce69a999604c76c86f0f9R128 Ok?