### PR TITLE
Update to signal-hook 0.3.8, signal-hook-mio 0.2.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,8 @@ crossterm_winapi = "0.7.0"
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 mio = { version="0.7", features=["os-poll"] }
-signal-hook = { version = "0.1.17", features = ["mio-0_7-support"] }
+signal-hook = { version = "0.3.8" }
+signal-hook-mio = { version = "0.2.1", features = ["support-v0_7"] }
 
 #
 # Dev dependencies (examples, ...)


### PR DESCRIPTION
Note, the documentation for creating an iterator from `&signals` suggests
it returns an infinite stream. I instead switched to `pending()`, since
presumably we don't want to block forever waiting for signals.