### PR TITLE
Remove writer parameter from execute_winapi

### DIFF
--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -67,7 +67,7 @@ impl Command for MoveTo {
     }
 
     #[cfg(windows)]
-    fn execute_winapi(&self, _writer: impl FnMut() -> Result<()>) -> Result<()> {
+    fn execute_winapi(&self) -> Result<()> {
         sys::move_to(self.0, self.1)
     }
 }
@@ -87,7 +87,7 @@ impl Command for MoveToNextLine {
     }
 
     #[cfg(windows)]
-    fn execute_winapi(&self, _writer: impl FnMut() -> Result<()>) -> Result<()> {
+    fn execute_winapi(&self) -> Result<()> {
         sys::move_to_next_line(self.0)
     }
 }
@@ -107,7 +107,7 @@ impl Command for MoveToPreviousLine {
     }
 
     #[cfg(windows)]
-    fn execute_winapi(&self, _writer: impl FnMut() -> Result<()>) -> Result<()> {
+    fn execute_winapi(&self) -> Result<()> {
         sys::move_to_previous_line(self.0)
     }
 }
@@ -126,7 +126,7 @@ impl Command for MoveToColumn {
     }
 
     #[cfg(windows)]
-    fn execute_winapi(&self, _writer: impl FnMut() -> Result<()>) -> Result<()> {
+    fn execute_winapi(&self) -> Result<()> {
         sys::move_to_column(self.0)
     }
 }
@@ -145,7 +145,7 @@ impl Command for MoveToRow {
     }
 
     #[cfg(windows)]
-    fn execute_winapi(&self, _writer: impl FnMut() -> Result<()>) -> Result<()> {
+    fn execute_winapi(&self) -> Result<()> {
         sys::move_to_row(self.0)
     }
 }
@@ -167,7 +167,7 @@ impl Command for MoveUp {
     }
 
     #[cfg(windows)]
-    fn execute_winapi(&self, _writer: impl FnMut() -> Result<()>) -> Result<()> {
+    fn execute_winapi(&self) -> Result<()> {
         sys::move_up(self.0)
     }
 }
@@ -189,7 +189,7 @@ impl Command for MoveRight {
     }
 
     #[cfg(windows)]
-    fn execute_winapi(&self, _writer: impl FnMut() -> Result<()>) -> Result<()> {
+    fn execute_winapi(&self) -> Result<()> {
         sys::move_right(self.0)
     }
 }
@@ -211,7 +211,7 @@ impl Command for MoveDown {
     }
 
     #[cfg(windows)]
-    fn execute_winapi(&self, _writer: impl FnMut() -> Result<()>) -> Result<()> {
+    fn execute_winapi(&self) -> Result<()> {
         sys::move_down(self.0)
     }
 }
@@ -233,7 +233,7 @@ impl Command for MoveLeft {
     }
 
     #[cfg(windows)]
-    fn execute_winapi(&self, _writer: impl FnMut() -> Result<()>) -> Result<()> {
+    fn execute_winapi(&self) -> Result<()> {
         sys::move_left(self.0)
     }
 }
@@ -255,7 +255,7 @@ impl Command for SavePosition {
     }
 
     #[cfg(windows)]
-    fn execute_winapi(&self, _writer: impl FnMut() -> Result<()>) -> Result<()> {
+    fn execute_winapi(&self) -> Result<()> {
         sys::save_position()
     }
 }
@@ -277,7 +277,7 @@ impl Command for RestorePosition {
     }
 
     #[cfg(windows)]
-    fn execute_winapi(&self, _writer: impl FnMut() -> Result<()>) -> Result<()> {
+    fn execute_winapi(&self) -> Result<()> {
         sys::restore_position()
     }
 }
@@ -296,7 +296,7 @@ impl Command for Hide {
     }
 
     #[cfg(windows)]
-    fn execute_winapi(&self, _writer: impl FnMut() -> Result<()>) -> Result<()> {
+    fn execute_winapi(&self) -> Result<()> {
         sys::show_cursor(false)
     }
 }
@@ -315,7 +315,7 @@ impl Command for Show {
     }
 
     #[cfg(windows)]
-    fn execute_winapi(&self, _writer: impl FnMut() -> Result<()>) -> Result<()> {
+    fn execute_winapi(&self) -> Result<()> {
         sys::show_cursor(true)
     }
 }
@@ -335,7 +335,7 @@ impl Command for EnableBlinking {
     }
 
     #[cfg(windows)]
-    fn execute_winapi(&self, _writer: impl FnMut() -> Result<()>) -> Result<()> {
+    fn execute_winapi(&self) -> Result<()> {
         Ok(())
     }
 }
@@ -355,7 +355,7 @@ impl Command for DisableBlinking {
     }
 
     #[cfg(windows)]
-    fn execute_winapi(&self, _writer: impl FnMut() -> Result<()>) -> Result<()> {
+    fn execute_winapi(&self) -> Result<()> {
         Ok(())
     }
 }
@@ -391,7 +391,7 @@ impl Command for SetCursorShape {
     }
 
     #[cfg(windows)]
-    fn execute_winapi(&self, _writer: impl FnMut() -> Result<()>) -> Result<()> {
+    fn execute_winapi(&self) -> Result<()> {
         Ok(())
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -255,7 +255,7 @@ impl Command for EnableMouseCapture {
     }
 
     #[cfg(windows)]
-    fn execute_winapi(&self, _writer: impl FnMut() -> Result<()>) -> Result<()> {
+    fn execute_winapi(&self) -> Result<()> {
         sys::windows::enable_mouse_capture()
     }
 
@@ -284,7 +284,7 @@ impl Command for DisableMouseCapture {
     }
 
     #[cfg(windows)]
-    fn execute_winapi(&self, _writer: impl FnMut() -> Result<()>) -> Result<()> {
+    fn execute_winapi(&self) -> Result<()> {
         sys::windows::disable_mouse_capture()
     }
 

--- a/src/event/sys/windows/parse.rs
+++ b/src/event/sys/windows/parse.rs
@@ -106,10 +106,7 @@ fn parse_key_event_record(key_event: &KeyEventRecord) -> Option<KeyEvent> {
                     Some(KeyCode::Char(character))
                 }
             } else {
-                match std::char::from_u32(character_raw as u32) {
-                    Some(ch) => Some(KeyCode::Char(ch)),
-                    None => None,
-                }
+                std::char::from_u32(character_raw as u32).map(KeyCode::Char)
             }
         }
     };

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -278,10 +278,7 @@ mod tests {
                 f.write_str(self.value)
             }
 
-            fn execute_winapi(
-                &self,
-                _writer: impl FnMut() -> CrosstermResult<()>,
-            ) -> CrosstermResult<()> {
+            fn execute_winapi(&self) -> CrosstermResult<()> {
                 self.stream.borrow_mut().push(self.value);
                 Ok(())
             }

--- a/src/style.rs
+++ b/src/style.rs
@@ -205,7 +205,7 @@ impl Command for SetForegroundColor {
     }
 
     #[cfg(windows)]
-    fn execute_winapi(&self, _writer: impl FnMut() -> Result<()>) -> Result<()> {
+    fn execute_winapi(&self) -> Result<()> {
         sys::windows::set_foreground_color(self.0)
     }
 }
@@ -229,7 +229,7 @@ impl Command for SetBackgroundColor {
     }
 
     #[cfg(windows)]
-    fn execute_winapi(&self, _writer: impl FnMut() -> Result<()>) -> Result<()> {
+    fn execute_winapi(&self) -> Result<()> {
         sys::windows::set_background_color(self.0)
     }
 }
@@ -270,7 +270,7 @@ impl Command for SetColors {
     }
 
     #[cfg(windows)]
-    fn execute_winapi(&self, _writer: impl FnMut() -> Result<()>) -> Result<()> {
+    fn execute_winapi(&self) -> Result<()> {
         if let Some(color) = self.0.foreground {
             sys::windows::set_foreground_color(color)?;
         }
@@ -297,7 +297,7 @@ impl Command for SetAttribute {
     }
 
     #[cfg(windows)]
-    fn execute_winapi(&self, _writer: impl FnMut() -> Result<()>) -> Result<()> {
+    fn execute_winapi(&self) -> Result<()> {
         // attributes are not supported by WinAPI.
         Ok(())
     }
@@ -324,7 +324,7 @@ impl Command for SetAttributes {
     }
 
     #[cfg(windows)]
-    fn execute_winapi(&self, _writer: impl FnMut() -> Result<()>) -> Result<()> {
+    fn execute_winapi(&self) -> Result<()> {
         // attributes are not supported by WinAPI.
         Ok(())
     }
@@ -346,7 +346,7 @@ impl<D: Display> Command for PrintStyledContent<D> {
     }
 
     #[cfg(windows)]
-    fn execute_winapi(&self, _writer: impl FnMut() -> Result<()>) -> Result<()> {
+    fn execute_winapi(&self) -> Result<()> {
         Ok(())
     }
 }
@@ -365,7 +365,7 @@ impl Command for ResetColor {
     }
 
     #[cfg(windows)]
-    fn execute_winapi(&self, _writer: impl FnMut() -> Result<()>) -> Result<()> {
+    fn execute_winapi(&self) -> Result<()> {
         sys::windows::reset()
     }
 }
@@ -382,8 +382,12 @@ impl<T: Display> Command for Print<T> {
     }
 
     #[cfg(windows)]
-    fn execute_winapi(&self, mut writer: impl FnMut() -> Result<()>) -> Result<()> {
-        writer()
+    fn execute_winapi(&self) -> Result<()> {
+        panic!("tried to execute Print command using WinAPI, use ANSI instead");
+    }
+
+    fn is_ansi_code_supported(&self) -> bool {
+        true
     }
 }
 

--- a/src/style.rs
+++ b/src/style.rs
@@ -408,5 +408,5 @@ impl_display!(for ResetColor);
 /// Utility function for ANSI parsing in Color and Colored.
 /// Gets the next element of `iter` and tries to parse it as a u8.
 fn parse_next_u8<'a>(iter: &mut impl Iterator<Item = &'a str>) -> Option<u8> {
-    iter.next().and_then(|s| u8::from_str_radix(s, 10).ok())
+    iter.next().and_then(|s| s.parse().ok())
 }

--- a/src/style.rs
+++ b/src/style.rs
@@ -386,6 +386,7 @@ impl<T: Display> Command for Print<T> {
         panic!("tried to execute Print command using WinAPI, use ANSI instead");
     }
 
+    #[cfg(windows)]
     fn is_ansi_code_supported(&self) -> bool {
         true
     }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -127,7 +127,7 @@ impl Command for DisableLineWrap {
     }
 
     #[cfg(windows)]
-    fn execute_winapi(&self, _writer: impl FnMut() -> Result<()>) -> Result<()> {
+    fn execute_winapi(&self) -> Result<()> {
         let screen_buffer = ScreenBuffer::current()?;
         let console_mode = ConsoleMode::from(screen_buffer.handle().clone());
         let new_mode = console_mode.mode()? & !ENABLE_WRAP_AT_EOL_OUTPUT;
@@ -146,7 +146,7 @@ impl Command for EnableLineWrap {
     }
 
     #[cfg(windows)]
-    fn execute_winapi(&self, _writer: impl FnMut() -> Result<()>) -> Result<()> {
+    fn execute_winapi(&self) -> Result<()> {
         let screen_buffer = ScreenBuffer::current()?;
         let console_mode = ConsoleMode::from(screen_buffer.handle().clone());
         let new_mode = console_mode.mode()? | ENABLE_WRAP_AT_EOL_OUTPUT;
@@ -186,7 +186,7 @@ impl Command for EnterAlternateScreen {
     }
 
     #[cfg(windows)]
-    fn execute_winapi(&self, _writer: impl FnMut() -> Result<()>) -> Result<()> {
+    fn execute_winapi(&self) -> Result<()> {
         let alternate_screen = ScreenBuffer::create();
         alternate_screen.show()?;
         Ok(())
@@ -224,7 +224,7 @@ impl Command for LeaveAlternateScreen {
     }
 
     #[cfg(windows)]
-    fn execute_winapi(&self, _writer: impl FnMut() -> Result<()>) -> Result<()> {
+    fn execute_winapi(&self) -> Result<()> {
         let screen_buffer = ScreenBuffer::from(Handle::current_out_handle()?);
         screen_buffer.show()?;
         Ok(())
@@ -264,7 +264,7 @@ impl Command for ScrollUp {
     }
 
     #[cfg(windows)]
-    fn execute_winapi(&self, _writer: impl FnMut() -> Result<()>) -> Result<()> {
+    fn execute_winapi(&self) -> Result<()> {
         sys::scroll_up(self.0)
     }
 }
@@ -286,7 +286,7 @@ impl Command for ScrollDown {
     }
 
     #[cfg(windows)]
-    fn execute_winapi(&self, _writer: impl FnMut() -> Result<()>) -> Result<()> {
+    fn execute_winapi(&self) -> Result<()> {
         sys::scroll_down(self.0)
     }
 }
@@ -313,7 +313,7 @@ impl Command for Clear {
     }
 
     #[cfg(windows)]
-    fn execute_winapi(&self, _writer: impl FnMut() -> Result<()>) -> Result<()> {
+    fn execute_winapi(&self) -> Result<()> {
         sys::clear(self.0)
     }
 }
@@ -332,7 +332,7 @@ impl Command for SetSize {
     }
 
     #[cfg(windows)]
-    fn execute_winapi(&self, _writer: impl FnMut() -> Result<()>) -> Result<()> {
+    fn execute_winapi(&self) -> Result<()> {
         sys::set_size(self.0, self.1)
     }
 }
@@ -351,7 +351,7 @@ impl<T: fmt::Display> Command for SetTitle<T> {
     }
 
     #[cfg(windows)]
-    fn execute_winapi(&self, _writer: impl FnMut() -> Result<()>) -> Result<()> {
+    fn execute_winapi(&self) -> Result<()> {
         sys::set_window_title(&self.0)
     }
 }

--- a/src/terminal/sys/windows.rs
+++ b/src/terminal/sys/windows.rs
@@ -371,7 +371,7 @@ mod tests {
         let test_title = "this is a crossterm test title";
         set_window_title(test_title).unwrap();
 
-        let mut raw = [0 as u16; 128];
+        let mut raw = [0_u16; 128];
         let length = unsafe { GetConsoleTitleW(raw.as_mut_ptr(), raw.len() as u32) } as usize;
         assert_ne!(0, length);
 


### PR DESCRIPTION
The only command that used this parameter was `Print`, which we can force to call `write_command_ansi` with by always returning `true` from `is_ansi_code_supported`. This does mean that `Print` will no longer call `.flush()` on the writer when queued, but any bugs potentially caused by that can be mitigated by flushing before calling any WinAPI commands.