### PR TITLE
Add types for ‘dimensions’

### DIFF
--- a/examples/event-read.rs
+++ b/examples/event-read.rs
@@ -31,7 +31,7 @@ fn print_events() -> Result<()> {
             println!("Cursor position: {:?}\r", position());
         }
 
-        if let Event::Resize { .. } = event {
+        if let Event::Resize(_) = event {
             let (original_size, new_size) = flush_resize_events(event);
             println!("Resize from: {:?}, to: {:?}", original_size, new_size);
         }

--- a/examples/interactive-demo/src/macros.rs
+++ b/examples/interactive-demo/src/macros.rs
@@ -12,7 +12,7 @@ macro_rules! run_tests {
                 $dst,
                 style::ResetColor,
                 terminal::Clear(terminal::ClearType::All),
-                cursor::MoveTo(1, 1),
+                cursor::MoveTo(cursor::CursorPosition { column: 1, row: 1 }),
                 cursor::Show,
                 cursor::EnableBlinking
             )?;

--- a/examples/interactive-demo/src/main.rs
+++ b/examples/interactive-demo/src/main.rs
@@ -45,7 +45,7 @@ where
             style::ResetColor,
             terminal::Clear(ClearType::All),
             cursor::Hide,
-            cursor::MoveTo(1, 1)
+            cursor::MoveTo(cursor::CursorPosition { column: 1, row: 1 })
         )?;
 
         for line in MENU.split('\n') {

--- a/examples/interactive-demo/src/test/color.rs
+++ b/examples/interactive-demo/src/test/color.rs
@@ -108,7 +108,10 @@ where
     for idx in 0..=15 {
         queue!(
             w,
-            cursor::MoveTo(1, idx + 4),
+            cursor::MoveTo(cursor::CursorPosition {
+                column: 1,
+                row: idx + 4
+            }),
             style::Print(format!("{:>width$}", idx, width = 2))
         )?;
         queue!(
@@ -119,7 +122,13 @@ where
     }
 
     for row in 0..=15u16 {
-        queue!(w, cursor::MoveTo(4, row + 4))?;
+        queue!(
+            w,
+            cursor::MoveTo(cursor::CursorPosition {
+                column: 4,
+                row: row + 4
+            })
+        )?;
         for col in 0..=15u16 {
             queue!(
                 w,

--- a/examples/interactive-demo/src/test/cursor.rs
+++ b/examples/interactive-demo/src/test/cursor.rs
@@ -3,7 +3,7 @@
 use std::io::Write;
 
 use crate::Result;
-use crossterm::{cursor, execute, queue, style, Command, style::Stylize};
+use crossterm::{cursor, execute, queue, style, style::Stylize, Command};
 use std::thread;
 use std::time::Duration;
 
@@ -112,13 +112,13 @@ where
     W: Write,
 {
     execute!(w,
-        cursor::MoveTo(0, 0),
+        cursor::MoveTo(CursorPosition { column: 0, row: 0 }),
         style::Print("Save position, print character else were, after three seconds restore to old position."),
         cursor::MoveToNextLine(2),
         style::Print("Save ->[ ]<- Position"),
-        cursor::MoveTo(8, 2),
+        cursor::MoveTo(CursorPosition { column: 8, row: 2 }),
         cursor::SavePosition,
-        cursor::MoveTo(10,10),
+        cursor::MoveTo(CursorPosition { column: 10, row: 10 }),
         style::Print("Move To ->[√]<- Position")
     )?;
 
@@ -137,7 +137,7 @@ where
     execute!(
         w,
         cursor::Hide,
-        cursor::MoveTo(0, 0),
+        cursor::MoveTo(CursorPosition { column: 0, row: 0 }),
         style::SetForegroundColor(style::Color::Red),
         style::Print(format!(
             "Red box is the center. After the action: '{}' another box is drawn.",

--- a/examples/stderr.rs
+++ b/examples/stderr.rs
@@ -11,7 +11,7 @@
 use std::io::{stderr, Write};
 
 use crossterm::{
-    cursor::{Hide, MoveTo, Show},
+    cursor::{CursorPosition, Hide, MoveTo, Show},
     event,
     event::{Event, KeyCode, KeyEvent},
     execute, queue,
@@ -58,7 +58,11 @@ where
 
     let mut y = 1;
     for line in TEXT.split('\n') {
-        queue!(write, MoveTo(1, y), Print(line.to_string()))?;
+        queue!(
+            write,
+            MoveTo(CursorPosition { column: 1, row: y }),
+            Print(line.to_string())
+        )?;
         y += 1;
     }
 

--- a/src/cursor/sys/windows.rs
+++ b/src/cursor/sys/windows.rs
@@ -10,7 +10,7 @@ use winapi::{
     um::wincon::{SetConsoleCursorInfo, SetConsoleCursorPosition, CONSOLE_CURSOR_INFO, COORD},
 };
 
-use crate::Result;
+use crate::{cursor::CursorPosition, Result};
 
 /// The position of the cursor, written when you save the cursor's position.
 ///
@@ -34,23 +34,23 @@ pub fn parse_relative_y(y: i16) -> Result<i16> {
     }
 }
 
-/// Returns the cursor position (column, row).
-///
-/// The top left cell is represented `0,0`.
-pub fn position() -> Result<(u16, u16)> {
+/// Returns the cursor position.
+pub fn position() -> Result<CursorPosition> {
     let cursor = ScreenBufferCursor::output()?;
     let mut position = cursor.position()?;
     //    if position.y != 0 {
     position.y = parse_relative_y(position.y)?;
     //    }
-    Ok(position.into())
+
+    let (column, row) = position.into();
+    Ok(CursorPosition { column, row })
 }
 
 pub(crate) fn show_cursor(show_cursor: bool) -> Result<()> {
     ScreenBufferCursor::from(Handle::current_out_handle()?).set_visibility(show_cursor)
 }
 
-pub(crate) fn move_to(column: u16, row: u16) -> Result<()> {
+pub(crate) fn move_to(CursorPosition { column, row }: CursorPosition) -> Result<()> {
     let cursor = ScreenBufferCursor::output()?;
     cursor.move_to(column as i16, row as i16)?;
     Ok(())

--- a/src/event.rs
+++ b/src/event.rs
@@ -91,6 +91,7 @@ use parking_lot::{MappedMutexGuard, Mutex, MutexGuard};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+use crate::cursor::CursorPosition;
 use crate::terminal::TerminalSize;
 use crate::{csi, Command, Result};
 use filter::{EventFilter, Filter};
@@ -515,9 +516,9 @@ pub enum KeyCode {
 pub(crate) enum InternalEvent {
     /// An event.
     Event(Event),
-    /// A cursor position (`col`, `row`).
+    /// A cursor position.
     #[cfg(unix)]
-    CursorPosition(u16, u16),
+    CursorPosition(CursorPosition),
 }
 
 #[cfg(test)]

--- a/src/event.rs
+++ b/src/event.rs
@@ -28,7 +28,10 @@
 //! Blocking read:
 //!
 //! ```no_run
-//! use crossterm::event::{read, Event};
+//! use crossterm::{
+//!     event::{read, Event},
+//!     terminal::TerminalSize,
+//! };
 //!
 //! fn print_events() -> crossterm::Result<()> {
 //!     loop {
@@ -36,7 +39,9 @@
 //!         match read()? {
 //!             Event::Key(event) => println!("{:?}", event),
 //!             Event::Mouse(event) => println!("{:?}", event),
-//!             Event::Resize(width, height) => println!("New size {}x{}", width, height),
+//!             Event::Resize(TerminalSize { width, height }) => {
+//!                 println!("New size {}x{}", width, height)
+//!             }
 //!         }
 //!     }
 //!     Ok(())
@@ -48,7 +53,10 @@
 //! ```no_run
 //! use std::time::Duration;
 //!
-//! use crossterm::event::{poll, read, Event};
+//! use crossterm::{
+//!     event::{poll, read, Event},
+//!     terminal::TerminalSize,
+//! };
 //!
 //! fn print_events() -> crossterm::Result<()> {
 //!     loop {
@@ -59,7 +67,9 @@
 //!             match read()? {
 //!                 Event::Key(event) => println!("{:?}", event),
 //!                 Event::Mouse(event) => println!("{:?}", event),
-//!                 Event::Resize(width, height) => println!("New size {}x{}", width, height),
+//!                 Event::Resize(TerminalSize { width, height }) => {
+//!                     println!("New size {}x{}", width, height)
+//!                 }
 //!             }
 //!         } else {
 //!             // Timeout expired and no `Event` is available
@@ -81,6 +91,7 @@ use parking_lot::{MappedMutexGuard, Mutex, MutexGuard};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+use crate::terminal::TerminalSize;
 use crate::{csi, Command, Result};
 use filter::{EventFilter, Filter};
 use read::InternalEventReader;
@@ -302,9 +313,9 @@ pub enum Event {
     Key(KeyEvent),
     /// A single mouse event with additional pressed modifiers.
     Mouse(MouseEvent),
-    /// An resize event with new dimensions after resize (columns, rows).
+    /// An resize event with new dimensions after resize.
     /// **Note** that resize events can be occur in batches.
-    Resize(u16, u16),
+    Resize(TerminalSize),
 }
 
 /// Represents a mouse event.

--- a/src/event/filter.rs
+++ b/src/event/filter.rs
@@ -13,7 +13,7 @@ pub(crate) struct CursorPositionFilter;
 #[cfg(unix)]
 impl Filter for CursorPositionFilter {
     fn eval(&self, event: &InternalEvent) -> bool {
-        matches!(*event, InternalEvent::CursorPosition(_, _))
+        matches!(*event, InternalEvent::CursorPosition(_))
     }
 }
 
@@ -47,6 +47,7 @@ mod tests {
     use super::{
         super::Event, CursorPositionFilter, EventFilter, Filter, InternalEvent, InternalEventFilter,
     };
+    use crate::cursor::CursorPosition;
     use crate::terminal::TerminalSize;
 
     #[test]
@@ -57,7 +58,12 @@ mod tests {
                 height: 10
             })))
         );
-        assert!(CursorPositionFilter.eval(&InternalEvent::CursorPosition(0, 0)));
+        assert!(
+            CursorPositionFilter.eval(&InternalEvent::CursorPosition(CursorPosition {
+                column: 0,
+                row: 0
+            }))
+        );
     }
 
     #[test]
@@ -68,7 +74,12 @@ mod tests {
                 height: 10
             })))
         );
-        assert!(!EventFilter.eval(&InternalEvent::CursorPosition(0, 0)));
+        assert!(
+            !EventFilter.eval(&InternalEvent::CursorPosition(CursorPosition {
+                column: 0,
+                row: 0
+            }))
+        );
     }
 
     #[test]
@@ -79,6 +90,11 @@ mod tests {
                 height: 10
             })))
         );
-        assert!(InternalEventFilter.eval(&InternalEvent::CursorPosition(0, 0)));
+        assert!(
+            InternalEventFilter.eval(&InternalEvent::CursorPosition(CursorPosition {
+                column: 0,
+                row: 0
+            }))
+        );
     }
 }

--- a/src/event/filter.rs
+++ b/src/event/filter.rs
@@ -47,22 +47,38 @@ mod tests {
     use super::{
         super::Event, CursorPositionFilter, EventFilter, Filter, InternalEvent, InternalEventFilter,
     };
+    use crate::terminal::TerminalSize;
 
     #[test]
     fn test_cursor_position_filter_filters_cursor_position() {
-        assert!(!CursorPositionFilter.eval(&InternalEvent::Event(Event::Resize(10, 10))));
+        assert!(
+            !CursorPositionFilter.eval(&InternalEvent::Event(Event::Resize(TerminalSize {
+                width: 10,
+                height: 10
+            })))
+        );
         assert!(CursorPositionFilter.eval(&InternalEvent::CursorPosition(0, 0)));
     }
 
     #[test]
     fn test_event_filter_filters_events() {
-        assert!(EventFilter.eval(&InternalEvent::Event(Event::Resize(10, 10))));
+        assert!(
+            EventFilter.eval(&InternalEvent::Event(Event::Resize(TerminalSize {
+                width: 10,
+                height: 10
+            })))
+        );
         assert!(!EventFilter.eval(&InternalEvent::CursorPosition(0, 0)));
     }
 
     #[test]
     fn test_event_filter_filters_internal_events() {
-        assert!(InternalEventFilter.eval(&InternalEvent::Event(Event::Resize(10, 10))));
+        assert!(
+            InternalEventFilter.eval(&InternalEvent::Event(Event::Resize(TerminalSize {
+                width: 10,
+                height: 10
+            })))
+        );
         assert!(InternalEventFilter.eval(&InternalEvent::CursorPosition(0, 0)));
     }
 }

--- a/src/event/read.rs
+++ b/src/event/read.rs
@@ -129,7 +129,7 @@ mod tests {
     use std::io;
     use std::{collections::VecDeque, time::Duration};
 
-    use crate::{terminal::TerminalSize, ErrorKind};
+    use crate::{cursor::CursorPosition, terminal::TerminalSize, ErrorKind};
 
     #[cfg(unix)]
     use super::super::filter::CursorPositionFilter;
@@ -179,7 +179,10 @@ mod tests {
                     width: 10,
                     height: 10,
                 })),
-                InternalEvent::CursorPosition(10, 20),
+                InternalEvent::CursorPosition(CursorPosition {
+                    column: 10,
+                    row: 20,
+                }),
             ]
             .into(),
             source: None,
@@ -208,7 +211,10 @@ mod tests {
     #[test]
     #[cfg(unix)]
     fn test_read_returns_matching_event_in_queue_at_back() {
-        const CURSOR_EVENT: InternalEvent = InternalEvent::CursorPosition(10, 20);
+        const CURSOR_EVENT: InternalEvent = InternalEvent::CursorPosition(CursorPosition {
+            column: 10,
+            row: 20,
+        });
 
         let mut reader = InternalEventReader {
             events: vec![
@@ -233,7 +239,10 @@ mod tests {
             width: 10,
             height: 10,
         }));
-        const CURSOR_EVENT: InternalEvent = InternalEvent::CursorPosition(10, 20);
+        const CURSOR_EVENT: InternalEvent = InternalEvent::CursorPosition(CursorPosition {
+            column: 10,
+            row: 20,
+        });
 
         let mut reader = InternalEventReader {
             events: vec![SKIPPED_EVENT, CURSOR_EVENT].into(),

--- a/src/event/read.rs
+++ b/src/event/read.rs
@@ -129,7 +129,7 @@ mod tests {
     use std::io;
     use std::{collections::VecDeque, time::Duration};
 
-    use crate::ErrorKind;
+    use crate::{terminal::TerminalSize, ErrorKind};
 
     #[cfg(unix)]
     use super::super::filter::CursorPositionFilter;
@@ -158,7 +158,11 @@ mod tests {
     #[test]
     fn test_poll_returns_true_for_matching_event_in_queue_at_front() {
         let mut reader = InternalEventReader {
-            events: vec![InternalEvent::Event(Event::Resize(10, 10))].into(),
+            events: vec![InternalEvent::Event(Event::Resize(TerminalSize {
+                width: 10,
+                height: 10,
+            }))]
+            .into(),
             source: None,
             skipped_events: Vec::with_capacity(32),
         };
@@ -171,7 +175,10 @@ mod tests {
     fn test_poll_returns_true_for_matching_event_in_queue_at_back() {
         let mut reader = InternalEventReader {
             events: vec![
-                InternalEvent::Event(Event::Resize(10, 10)),
+                InternalEvent::Event(Event::Resize(TerminalSize {
+                    width: 10,
+                    height: 10,
+                })),
                 InternalEvent::CursorPosition(10, 20),
             ]
             .into(),
@@ -184,7 +191,10 @@ mod tests {
 
     #[test]
     fn test_read_returns_matching_event_in_queue_at_front() {
-        const EVENT: InternalEvent = InternalEvent::Event(Event::Resize(10, 10));
+        const EVENT: InternalEvent = InternalEvent::Event(Event::Resize(TerminalSize {
+            width: 10,
+            height: 10,
+        }));
 
         let mut reader = InternalEventReader {
             events: vec![EVENT].into(),
@@ -201,7 +211,14 @@ mod tests {
         const CURSOR_EVENT: InternalEvent = InternalEvent::CursorPosition(10, 20);
 
         let mut reader = InternalEventReader {
-            events: vec![InternalEvent::Event(Event::Resize(10, 10)), CURSOR_EVENT].into(),
+            events: vec![
+                InternalEvent::Event(Event::Resize(TerminalSize {
+                    width: 10,
+                    height: 10,
+                })),
+                CURSOR_EVENT,
+            ]
+            .into(),
             source: None,
             skipped_events: Vec::with_capacity(32),
         };
@@ -212,7 +229,10 @@ mod tests {
     #[test]
     #[cfg(unix)]
     fn test_read_does_not_consume_skipped_event() {
-        const SKIPPED_EVENT: InternalEvent = InternalEvent::Event(Event::Resize(10, 10));
+        const SKIPPED_EVENT: InternalEvent = InternalEvent::Event(Event::Resize(TerminalSize {
+            width: 10,
+            height: 10,
+        }));
         const CURSOR_EVENT: InternalEvent = InternalEvent::CursorPosition(10, 20);
 
         let mut reader = InternalEventReader {
@@ -242,7 +262,11 @@ mod tests {
 
     #[test]
     fn test_poll_returns_true_if_source_has_at_least_one_event() {
-        let source = FakeSource::with_events(&[InternalEvent::Event(Event::Resize(10, 10))]);
+        let source =
+            FakeSource::with_events(&[InternalEvent::Event(Event::Resize(TerminalSize {
+                width: 10,
+                height: 10,
+            }))]);
 
         let mut reader = InternalEventReader {
             events: VecDeque::new(),
@@ -258,7 +282,10 @@ mod tests {
 
     #[test]
     fn test_reads_returns_event_if_source_has_at_least_one_event() {
-        const EVENT: InternalEvent = InternalEvent::Event(Event::Resize(10, 10));
+        const EVENT: InternalEvent = InternalEvent::Event(Event::Resize(TerminalSize {
+            width: 10,
+            height: 10,
+        }));
 
         let source = FakeSource::with_events(&[EVENT]);
 
@@ -273,7 +300,10 @@ mod tests {
 
     #[test]
     fn test_read_returns_events_if_source_has_events() {
-        const EVENT: InternalEvent = InternalEvent::Event(Event::Resize(10, 10));
+        const EVENT: InternalEvent = InternalEvent::Event(Event::Resize(TerminalSize {
+            width: 10,
+            height: 10,
+        }));
 
         let source = FakeSource::with_events(&[EVENT, EVENT, EVENT]);
 
@@ -290,7 +320,10 @@ mod tests {
 
     #[test]
     fn test_poll_returns_false_after_all_source_events_are_consumed() {
-        const EVENT: InternalEvent = InternalEvent::Event(Event::Resize(10, 10));
+        const EVENT: InternalEvent = InternalEvent::Event(Event::Resize(TerminalSize {
+            width: 10,
+            height: 10,
+        }));
 
         let source = FakeSource::with_events(&[EVENT, EVENT, EVENT]);
 
@@ -348,7 +381,10 @@ mod tests {
 
     #[test]
     fn test_poll_continues_after_error() {
-        const EVENT: InternalEvent = InternalEvent::Event(Event::Resize(10, 10));
+        const EVENT: InternalEvent = InternalEvent::Event(Event::Resize(TerminalSize {
+            width: 10,
+            height: 10,
+        }));
 
         let source = FakeSource::new(&[EVENT, EVENT], ErrorKind::from(io::ErrorKind::Other));
 
@@ -367,7 +403,10 @@ mod tests {
 
     #[test]
     fn test_read_continues_after_error() {
-        const EVENT: InternalEvent = InternalEvent::Event(Event::Resize(10, 10));
+        const EVENT: InternalEvent = InternalEvent::Event(Event::Resize(TerminalSize {
+            width: 10,
+            height: 10,
+        }));
 
         let source = FakeSource::new(&[EVENT, EVENT], ErrorKind::from(io::ErrorKind::Other));
 

--- a/src/event/source/unix.rs
+++ b/src/event/source/unix.rs
@@ -138,9 +138,7 @@ impl EventSource for UnixInternalEventSource {
                                     // it's a really long time from the mio, async-std/tokio executor, ...
                                     // point of view.
                                     let new_size = crate::terminal::size()?;
-                                    return Ok(Some(InternalEvent::Event(Event::Resize(
-                                        new_size.0, new_size.1,
-                                    ))));
+                                    return Ok(Some(InternalEvent::Event(Event::Resize(new_size))));
                                 }
                                 _ => unreachable!("Synchronize signal registration & handling"),
                             };

--- a/src/event/source/windows.rs
+++ b/src/event/source/windows.rs
@@ -44,7 +44,10 @@ impl EventSource for WindowsEventSource {
                         InputRecord::KeyEvent(record) => handle_key_event(record),
                         InputRecord::MouseEvent(record) => handle_mouse_event(record),
                         InputRecord::WindowBufferSizeEvent(record) => {
-                            Some(Event::Resize(record.size.x as u16, record.size.y as u16))
+                            Some(Event::Resize(TerminalSize {
+                                width: record.size.x as u16,
+                                height: record.size.y as u16,
+                            }))
                         }
                         _ => None,
                     };

--- a/src/event/sys/unix/parse.rs
+++ b/src/event/sys/unix/parse.rs
@@ -1,6 +1,7 @@
 use std::io;
 
 use crate::{
+    cursor::CursorPosition,
     event::{Event, KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind},
     ErrorKind, Result,
 };
@@ -193,10 +194,13 @@ pub(crate) fn parse_csi_cursor_position(buffer: &[u8]) -> Result<Option<Internal
 
     let mut split = s.split(';');
 
-    let y = next_parsed::<u16>(&mut split)? - 1;
-    let x = next_parsed::<u16>(&mut split)? - 1;
+    let row = next_parsed::<u16>(&mut split)? - 1;
+    let column = next_parsed::<u16>(&mut split)? - 1;
 
-    Ok(Some(InternalEvent::CursorPosition(x, y)))
+    Ok(Some(InternalEvent::CursorPosition(CursorPosition {
+        column,
+        row,
+    })))
 }
 
 fn parse_modifiers(mask: u8) -> KeyModifiers {
@@ -524,7 +528,10 @@ mod tests {
         // parse_csi_cursor_position
         assert_eq!(
             parse_event(b"\x1B[20;10R", false).unwrap(),
-            Some(InternalEvent::CursorPosition(9, 19))
+            Some(InternalEvent::CursorPosition(CursorPosition {
+                column: 9,
+                row: 19
+            }))
         );
 
         // parse_csi
@@ -603,7 +610,10 @@ mod tests {
     fn test_parse_csi_cursor_position() {
         assert_eq!(
             parse_csi_cursor_position(b"\x1B[20;10R").unwrap(),
-            Some(InternalEvent::CursorPosition(9, 19))
+            Some(InternalEvent::CursorPosition(CursorPosition {
+                column: 9,
+                row: 19
+            }))
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,7 @@
 //! use crossterm::{QueueableCommand, cursor};
 //!
 //! let mut stdout = stdout();
-//! stdout.queue(cursor::MoveTo(5,5));
+//! stdout.queue(cursor::MoveTo(cursor::CursorPosition { column: 5, row: 5 }));
 //!
 //! // some other code ...
 //!
@@ -118,7 +118,7 @@
 //! use crossterm::{queue, QueueableCommand, cursor};
 //!
 //! let mut stdout = stdout();
-//! queue!(stdout,  cursor::MoveTo(5, 5));
+//! queue!(stdout,  cursor::MoveTo(cursor::CursorPosition { column: 5, row: 5 }));
 //!
 //! // some other code ...
 //!
@@ -127,7 +127,7 @@
 //! ```
 //!
 //! You can pass more than one command into the [queue](./macro.queue.html) macro like
-//! `queue!(stdout, MoveTo(5, 5), Clear(ClearType::All))` and
+//! `queue!(stdout, MoveTo(CursorPosition { column: 5, row: 5 }), Clear(ClearType::All))` and
 //! they will be executed in the given order from left to right.
 //!
 //! #### Direct Execution
@@ -149,7 +149,7 @@
 //! use crossterm::{ExecutableCommand, cursor};
 //!
 //! let mut stdout = stdout();
-//! stdout.execute(cursor::MoveTo(5,5));
+//! stdout.execute(cursor::MoveTo(cursor::CursorPosition { column: 5, row: 5 }));
 //! ```
 //! The [execute](./trait.ExecutableCommand.html) function returns itself, therefore you can use this to queue
 //! another command. Like `stdout.queue(Goto(5,5)).queue(Clear(ClearType::All))`.
@@ -161,11 +161,11 @@
 //! use crossterm::{execute, ExecutableCommand, cursor};
 //!
 //! let mut stdout = stdout();
-//! execute!(stdout, cursor::MoveTo(5, 5));
+//! execute!(stdout, cursor::MoveTo(cursor::CursorPosition { column: 5, row: 5 }));
 //! ```
 //! You can pass more than one command into the [execute](./macro.execute.html) macro like
-//! `execute!(stdout, MoveTo(5, 5), Clear(ClearType::All))` and they will be executed in the given order from
-//! left to right.
+//! `execute!(stdout, MoveTo(cursor::CursorPosition { column: 5, row: 5 }), Clear(ClearType::All))`
+//! and they will be executed in the given order from left to right.
 //!
 //! ## Examples
 //!
@@ -190,7 +190,7 @@
 //!       if (y == 0 || y == 40 - 1) || (x == 0 || x == 150 - 1) {
 //!         // in this loop we are more efficient by not flushing the buffer.
 //!         stdout
-//!           .queue(cursor::MoveTo(x,y))?
+//!           .queue(cursor::MoveTo(cursor::CursorPosition { column: x, row: y }))?
 //!           .queue(style::PrintStyledContent( "█".magenta()))?;
 //!       }
 //!     }
@@ -218,7 +218,11 @@
 //!     for x in 0..150 {
 //!       if (y == 0 || y == 40 - 1) || (x == 0 || x == 150 - 1) {
 //!         // in this loop we are more efficient by not flushing the buffer.
-//!         queue!(stdout, cursor::MoveTo(x,y), style::PrintStyledContent( "█".magenta()))?;
+//!         queue!(
+//!           stdout,
+//!           cursor::MoveTo(cursor::CursorPosition { column: x, row: y }),
+//!           style::PrintStyledContent("█".magenta())
+//!         )?;
 //!       }
 //!     }
 //!   }

--- a/src/terminal/sys/windows.rs
+++ b/src/terminal/sys/windows.rs
@@ -9,7 +9,11 @@ use winapi::{
     um::wincon::{SetConsoleTitleW, ENABLE_ECHO_INPUT, ENABLE_LINE_INPUT, ENABLE_PROCESSED_INPUT},
 };
 
-use crate::{cursor, terminal::ClearType, ErrorKind, Result};
+use crate::{
+    cursor,
+    terminal::{ClearType, TerminalSize},
+    ErrorKind, Result,
+};
 
 const RAW_MODE_MASK: DWORD = ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT | ENABLE_PROCESSED_INPUT;
 
@@ -37,13 +41,13 @@ pub(crate) fn disable_raw_mode() -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn size() -> Result<(u16, u16)> {
+pub(crate) fn size() -> Result<TerminalSize> {
     let terminal_size = ScreenBuffer::current()?.info()?.terminal_size();
     // windows starts counting at 0, unix at 1, add one to replicated unix behaviour.
-    Ok((
-        (terminal_size.width + 1) as u16,
-        (terminal_size.height + 1) as u16,
-    ))
+    Ok(TerminalSize {
+        width: (terminal_size.width + 1) as u16,
+        height: (terminal_size.height + 1) as u16,
+    })
 }
 
 pub(crate) fn clear(clear_type: ClearType) -> Result<()> {
@@ -98,7 +102,7 @@ pub(crate) fn scroll_down(row_count: u16) -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn set_size(width: u16, height: u16) -> Result<()> {
+pub(crate) fn set_size(TerminalSize { width, height }: TerminalSize) -> Result<()> {
     if width <= 1 {
         return Err(ErrorKind::new(
             io::ErrorKind::InvalidInput,


### PR DESCRIPTION
This PR extracts types for both the size of the terminal window, as well as the cursor’s position. Previously the coordinate order for these was specified only in documentation, which has led to a number of bugs in my own code. If, as a user of crossterm, I have to spell out that I am accessing the cursor’s `column` or the window’s `width`, I am much less likely to make such a mistake.

I understand this change is subjective and might make code too wordy for the tastes of some, so feel free to close if you disagree.

I don’t have access to a Windows device, so I probably haven’t fixed all the errors in the Windows portion of this PR.