### PR TITLE
Docs: Add some links related to raw mode

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -15,7 +15,7 @@
 //! * use the [`read`](fn.read.html) & [`poll`](fn.poll.html) functions on any, but same, thread
 //! * or the [`EventStream`](struct.EventStream.html).
 //!
-//! **Make sure to enable raw mode in order for keyboard events to work properly**
+//! **Make sure to enable [raw mode](../terminal/#raw-mode) in order for keyboard events to work properly**
 //!
 //! ## Mouse Events
 //!

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -58,6 +58,8 @@
 //! - Special keys like backspace and CTL+C will not be processed by terminal driver
 //! - New line character will not be processed therefore `println!` can't be used, use `write!` instead
 //!
+//! Raw mode can be enabled/disabled with the [enable_raw_mode](terminal::enable_raw_mode) and [disable_raw_mode](terminal::disable_raw_mode) functions.
+//!
 //! ## Examples
 //!
 //! ```no_run


### PR DESCRIPTION
Hi! I just started trying out crossterm and I think having these links make the docs a bit easier to navigate.

I didn't use `code` style in the links to the enable/disable functions, because I saw that it was not used elsewhere. Or is that incorrect?