### PR TITLE
Fix Greys in colors table

### DIFF
--- a/src/style/types/color.rs
+++ b/src/style/types/color.rs
@@ -16,14 +16,14 @@ use crate::style::parse_next_u8;
 ///
 /// | Light | Dark |
 /// | :--| :--   |
-/// | `Grey` | `Black` |
+/// | `DarkGrey` | `Black` |
 /// | `Red` | `DarkRed` |
 /// | `Green` | `DarkGreen` |
 /// | `Yellow` | `DarkYellow` |
 /// | `Blue` | `DarkBlue` |
 /// | `Magenta` | `DarkMagenta` |
 /// | `Cyan` | `DarkCyan` |
-/// | `White` | `DarkWhite` |
+/// | `White` | `Grey` |
 ///
 /// Most UNIX terminals and Windows 10 consoles support additional colors.
 /// See [`Color::Rgb`] or [`Color::AnsiValue`] for more info.


### PR DESCRIPTION
I came across the same as issue #573. This PR makes the docs consistent with the code (I checked that `DarkGrey` is darker than `Grey` which is darker than `White`).

However, it should be noted that at least in the table [here](https://en.wikipedia.org/wiki/ANSI_escape_code#3-bit_and_4-bit), "white" is what crossterm calls "grey", "bright black" or "gray" is what crossterm calls "dark grey" and "bright white" is what crossterm calls "white". With a quick search I couldn't find another good reference for these names.