### PR TITLE
expose terminal::is_raw_mode_enabled()

### DIFF
--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -410,7 +410,6 @@ mod tests {
 
     #[test]
     fn test_raw_mode() {
-
         // check we start from normal mode (may fail on some test harnesses)
         assert_eq!(is_raw_mode_enabled().unwrap(), false);
 

--- a/src/terminal/sys.rs
+++ b/src/terminal/sys.rs
@@ -4,8 +4,8 @@
 pub(crate) use self::unix::{disable_raw_mode, enable_raw_mode, is_raw_mode_enabled, size};
 #[cfg(windows)]
 pub(crate) use self::windows::{
-    clear, disable_raw_mode, enable_raw_mode, scroll_down, scroll_up, set_size, set_window_title,
-    size,
+    clear, disable_raw_mode, enable_raw_mode, is_raw_mode_enabled, scroll_down, scroll_up,
+    set_size, set_window_title, size,
 };
 
 #[cfg(windows)]

--- a/src/terminal/sys/unix.rs
+++ b/src/terminal/sys/unix.rs
@@ -67,6 +67,11 @@ pub(crate) fn enable_raw_mode() -> Result<()> {
     Ok(())
 }
 
+/// Reset the raw mode.
+///
+/// More precisely, reset the whole termios mode to what it was before the first call
+/// to [enable_raw_mode]. If you don't mess with termios outside of crossterm, it's
+/// effectively disabling the raw mode and doing nothing else.
 pub(crate) fn disable_raw_mode() -> Result<()> {
     let mut original_mode = TERMINAL_MODE_PRIOR_RAW_MODE.lock();
 


### PR DESCRIPTION
This enables functions which have to work both when the
raw mode is already set and when it isn't:

```
fn query(some_args) -> Result<SomeType, SomeError> {
    use crossterm::terminal::*;
    let switch_to_raw = !is_raw_mode_enabled()?;
    if switch_to_raw {
        enable_raw_mode()?;
    }
    let res = query_in_raw(some_args);
    if switch_to_raw {
        disable_raw_mode()?;
    }
    res
}
```