### PR TITLE
Changed MoveToNextLine(0) and MoveToPreviousLine(0) to move 0 lines

### DIFF
--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -77,19 +77,24 @@ impl Command for MoveTo {
 ///
 /// # Notes
 ///
-/// * Moves a minimum of 1 line.
-/// * Commands must be executed/queued for execution otherwise they do nothing.
+/// Commands must be executed/queued for execution otherwise they do nothing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MoveToNextLine(pub u16);
 
 impl Command for MoveToNextLine {
     fn write_ansi(&self, f: &mut impl fmt::Write) -> fmt::Result {
-        write!(f, csi!("{}E"), self.0)
+        if self.0 != 0 {
+            write!(f, csi!("{}E"), self.0)?;
+        }
+        Ok(())
     }
 
     #[cfg(windows)]
     fn execute_winapi(&self) -> Result<()> {
-        sys::move_to_next_line(self.0)
+        if self.0 != 0 {
+            sys::move_to_next_line(self.0)?;
+        }
+        Ok(())
     }
 }
 
@@ -98,19 +103,24 @@ impl Command for MoveToNextLine {
 ///
 /// # Notes
 ///
-/// * Moves a minimum of 1 line.
-/// * Commands must be executed/queued for execution otherwise they do nothing.
+/// Commands must be executed/queued for execution otherwise they do nothing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MoveToPreviousLine(pub u16);
 
 impl Command for MoveToPreviousLine {
     fn write_ansi(&self, f: &mut impl fmt::Write) -> fmt::Result {
-        write!(f, csi!("{}F"), self.0)
+        if self.0 != 0 {
+            write!(f, csi!("{}F"), self.0)?;
+        }
+        Ok(())
     }
 
     #[cfg(windows)]
     fn execute_winapi(&self) -> Result<()> {
-        sys::move_to_previous_line(self.0)
+        if self.0 != 0 {
+            sys::move_to_previous_line(self.0)?;
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
this pr specifies the minimum cursor line movement in commands `cursor::MoveToNextLine` and `cursor::MoveToPreviousLine` (see #599)

are there any exceptions to the behavior outlined in #599? i don't want to make a blanket statement that they will always move a minimum of 1 line, given 0.