### PR TITLE
make KeyEvent::new a const fn

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -395,7 +395,7 @@ pub struct KeyEvent {
 }
 
 impl KeyEvent {
-    pub fn new(code: KeyCode, modifiers: KeyModifiers) -> KeyEvent {
+    pub const fn new(code: KeyCode, modifiers: KeyModifiers) -> KeyEvent {
         KeyEvent { code, modifiers }
     }
 


### PR DESCRIPTION
This enables a more convenient declaration of const keys,
for example

```rs
pub const CONTROL_C: KeyEvent = KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL);
```

Note that other functions could probably be made const, I changed only
this one because I very frequently declare const keys.

If you want I may have a wider look.