### PR TITLE
make windows key parsing logic better

### DIFF
--- a/src/event/sys/windows/parse.rs
+++ b/src/event/sys/windows/parse.rs
@@ -95,7 +95,7 @@ fn parse_key_event_record(key_event: &KeyEventRecord) -> Option<KeyEvent> {
                     // it with 31, forcing bits 6 and bits 7 to zero.
                     // So we can make a bitwise OR back to see what's the raw control character.
                     let c = character_raw as u8;
-                    if c < b'\x1F' {
+                    if c <= b'\x1F' {
                         character = (c | b'\x40') as char;
                     } else {
                         return None;

--- a/src/event/sys/windows/parse.rs
+++ b/src/event/sys/windows/parse.rs
@@ -91,10 +91,14 @@ fn parse_key_event_record(key_event: &KeyEventRecord) -> Option<KeyEvent> {
                     && !modifiers.contains(KeyModifiers::ALT)
                 {
                     // we need to do some parsing
-                    character = match character_raw as u8 {
-                        c @ b'\x01'..=b'\x1A' => (c as u8 - 0x1 + b'a') as char,
-                        c @ b'\x1C'..=b'\x1F' => (c as u8 - 0x1C + b'4') as char,
-                        _ => return None,
+                    // Control character will take the ASCII code produced by the key and bitwise AND
+                    // it with 31, forcing bits 6 and bits 7 to zero.
+                    // So we can make a bitwise OR back to see what's the raw control character.
+                    let c = character_raw as u8;
+                    if c < b'\x1F' {
+                        character = (c | b'\x40') as char;
+                    } else {
+                        return None;
                     }
                 }
 


### PR DESCRIPTION
Handle #536 in windows

For more reference about the comment:
> The other implementation is to take the ASCII code produced by the key and bitwise AND it with 31, forcing bits 6 and 7 to zero. For example, pressing "control" and the letter "g" or "G" (code 107 in octal or 71 in base 10, which is 01000111 in binary), produces the code 7 (Bell, 7 in base 10, or 00000111 in binary).

https://en.wikipedia.org/wiki/Control_character

And here:
> Pressing Ctrl together with a letter or other symbol written 10xxxxx₂ (binary notation) sends the control character whose code is 00xxxxx₂, e.g. Ctrl+[ sends character number 27₁₀ = 0011011₂ because [ is 91₁₀ = 1011011₂.

https://vi.stackexchange.com/questions/3225/disable-esc-but-keep-c