### PR TITLE
fix control-character parsing in windows

### DIFF
--- a/src/event/sys/windows/parse.rs
+++ b/src/event/sys/windows/parse.rs
@@ -99,7 +99,7 @@ fn parse_key_event_record(key_event: &KeyEventRecord) -> Option<KeyEvent> {
                         character = (c | b'\x40') as char;
                         // if we press something like ctrl-g, we will get `character` with value `G`.
                         // in this case, convert the `character` to lowercase `g`.
-                        if character.is_ascii_uppercase() {
+                        if character.is_ascii_uppercase() && !modifiers.contains(KeyModifiers::SHIFT) {
                             character.make_ascii_lowercase();
                         }
                     } else {

--- a/src/event/sys/windows/parse.rs
+++ b/src/event/sys/windows/parse.rs
@@ -97,6 +97,11 @@ fn parse_key_event_record(key_event: &KeyEventRecord) -> Option<KeyEvent> {
                     let c = character_raw as u8;
                     if c <= b'\x1F' {
                         character = (c | b'\x40') as char;
+                        // if we press something like ctrl-g, we will get `character` with value `G`.
+                        // in this case, convert the `character` to lowercase `g`.
+                        if character.is_ascii_uppercase() {
+                            character.make_ascii_lowercase();
+                        }
                     } else {
                         return None;
                     }

--- a/src/event/sys/windows/parse.rs
+++ b/src/event/sys/windows/parse.rs
@@ -99,7 +99,9 @@ fn parse_key_event_record(key_event: &KeyEventRecord) -> Option<KeyEvent> {
                         character = (c | b'\x40') as char;
                         // if we press something like ctrl-g, we will get `character` with value `G`.
                         // in this case, convert the `character` to lowercase `g`.
-                        if character.is_ascii_uppercase() && !modifiers.contains(KeyModifiers::SHIFT) {
+                        if character.is_ascii_uppercase()
+                            && !modifiers.contains(KeyModifiers::SHIFT)
+                        {
                             character.make_ascii_lowercase();
                         }
                     } else {

--- a/src/style/sys/windows.rs
+++ b/src/style/sys/windows.rs
@@ -28,10 +28,9 @@ pub(crate) fn set_foreground_color(fg_color: Color) -> Result<()> {
 
     // Notice that the color values are stored in wAttribute.
     // So we need to use bitwise operators to check if the values exists or to get current console colors.
-    let mut color: u16;
     let attrs = csbi.attributes();
     let bg_color = attrs & 0x0070;
-    color = color_value | bg_color;
+    let mut color = color_value | bg_color;
 
     // background intensity is a separate value in attrs,
     // wee need to check if this was applied to the current bg color.
@@ -53,10 +52,9 @@ pub(crate) fn set_background_color(bg_color: Color) -> Result<()> {
 
     // Notice that the color values are stored in wAttribute.
     // So wee need to use bitwise operators to check if the values exists or to get current console colors.
-    let mut color: u16;
     let attrs = csbi.attributes();
     let fg_color = attrs & 0x0007;
-    color = fg_color | color_value;
+    let mut color = fg_color | color_value;
 
     // Foreground intensity is a separate value in attrs,
     // So we need to check if this was applied to the current fg color.


### PR DESCRIPTION
Sorry for introducing a new bug in #619 

The bug is: when user enters `ctrl-g`, the result will be `G with modifier CONTROL`.  And we need to convert from upper case `G` to lowercase `g`.

This pr is trying to fix it.