### PR TITLE
Fix links in docs

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -8,13 +8,13 @@ use super::error::Result;
 /// Crossterm provides a set of commands,
 /// and there is no immediate reason to implement a command yourself.
 /// In order to understand how to use and execute commands,
-/// it is recommended that you take a look at [Command API](../#command-api) chapter.
+/// it is recommended that you take a look at [Command API](./index.html#command-api) chapter.
 pub trait Command {
     /// Write an ANSI representation of this command to the given writer.
     /// An ANSI code can manipulate the terminal by writing it to the terminal buffer.
     /// However, only Windows 10 and UNIX systems support this.
     ///
-    /// This method does not need to be accessed manually, as it is used by the crossterm's [Command API](../#command-api)
+    /// This method does not need to be accessed manually, as it is used by the crossterm's [Command API](./index.html#command-api)
     fn write_ansi(&self, f: &mut impl fmt::Write) -> fmt::Result;
 
     /// Execute this command.
@@ -22,7 +22,7 @@ pub trait Command {
     /// Windows versions lower than windows 10 do not support ANSI escape codes,
     /// therefore a direct WinAPI call is made.
     ///
-    /// This method does not need to be accessed manually, as it is used by the crossterm's [Command API](../#command-api)
+    /// This method does not need to be accessed manually, as it is used by the crossterm's [Command API](./index.html#command-api)
     #[cfg(windows)]
     fn execute_winapi(&self) -> Result<()>;
 
@@ -109,7 +109,7 @@ impl<T: Write + ?Sized> QueueableCommand for T {
     /// }
     /// ```
     ///
-    /// Have a look over at the [Command API](./#command-api) for more details.
+    /// Have a look over at the [Command API](./index.html#command-api) for more details.
     ///
     /// # Notes
     ///
@@ -167,7 +167,7 @@ impl<T: Write + ?Sized> ExecutableCommand for T {
     ///  }
     /// ```
     ///
-    /// Have a look over at the [Command API](./#command-api) for more details.
+    /// Have a look over at the [Command API](./index.html#command-api) for more details.
     ///
     /// # Notes
     ///

--- a/src/event.rs
+++ b/src/event.rs
@@ -15,12 +15,12 @@
 //! * use the [`read`](fn.read.html) & [`poll`](fn.poll.html) functions on any, but same, thread
 //! * or the [`EventStream`](struct.EventStream.html).
 //!
-//! **Make sure to enable [raw mode](../terminal/#raw-mode) in order for keyboard events to work properly**
+//! **Make sure to enable [raw mode](./terminal/index.html#raw-mode) in order for keyboard events to work properly**
 //!
 //! ## Mouse Events
 //!
 //! Mouse events are not enabled by default. You have to enable them with the
-//! [`EnableMouseCapture`](struct.EnableMouseCapture.html) command. See [Command API](../index.html#command-api)
+//! [`EnableMouseCapture`](struct.EnableMouseCapture.html) command. See [Command API](./index.html#command-api)
 //! for more information.
 //!
 //! ## Examples

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -44,7 +44,7 @@ macro_rules! csi {
 /// // foo
 /// ```
 ///
-/// Have a look over at the [Command API](./#command-api) for more details.
+/// Have a look over at the [Command API](./index.html#command-api) for more details.
 ///
 /// # Notes
 ///
@@ -95,7 +95,7 @@ macro_rules! queue {
 /// // 1 + 1 = 2
 /// ```
 ///
-/// Have a look over at the [Command API](./#command-api) for more details.
+/// Have a look over at the [Command API](./index.html#command-api) for more details.
 ///
 /// # Notes
 ///

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -100,7 +100,7 @@ pub(crate) mod sys;
 
 /// Tells whether the raw mode is enabled.
 ///
-/// Please have a look at the [raw mode](./#raw-mode) section.
+/// Please have a look at the [raw mode](./index.html#raw-mode) section.
 pub fn is_raw_mode_enabled() -> Result<bool> {
     #[cfg(unix)]
     {
@@ -115,14 +115,14 @@ pub fn is_raw_mode_enabled() -> Result<bool> {
 
 /// Enables raw mode.
 ///
-/// Please have a look at the [raw mode](./#raw-mode) section.
+/// Please have a look at the [raw mode](./index.html#raw-mode) section.
 pub fn enable_raw_mode() -> Result<()> {
     sys::enable_raw_mode()
 }
 
 /// Disables raw mode.
 ///
-/// Please have a look at the [raw mode](./#raw-mode) section.
+/// Please have a look at the [raw mode](./index.html#raw-mode) section.
 pub fn disable_raw_mode() -> Result<()> {
     sys::disable_raw_mode()
 }


### PR DESCRIPTION
Some of these links did not work when browsing documentation locally (with `cargo doc --open`) because, when viewing local files, browsers do not redirect `something/` links to `something/index.html` and just show all files in `something/` directory.

~I hope this doesn't break online docs browsing as I don't know how to check it.~
Edit: I have checked with local webserver and this works.