### PR TITLE
Windows input improvements

### DIFF
--- a/src/event/sys/windows/parse.rs
+++ b/src/event/sys/windows/parse.rs
@@ -1,12 +1,14 @@
 use crossterm_winapi::{ControlKeyState, EventFlags, KeyEventRecord, MouseEvent, ScreenBuffer};
 use winapi::um::{
     wincon::{
-        LEFT_ALT_PRESSED, LEFT_CTRL_PRESSED, RIGHT_ALT_PRESSED, RIGHT_CTRL_PRESSED, SHIFT_PRESSED,
+        CAPSLOCK_ON, LEFT_ALT_PRESSED, LEFT_CTRL_PRESSED, RIGHT_ALT_PRESSED, RIGHT_CTRL_PRESSED,
+        SHIFT_PRESSED,
     },
     winuser::{
-        VK_BACK, VK_CONTROL, VK_DELETE, VK_DOWN, VK_END, VK_ESCAPE, VK_F1, VK_F24, VK_HOME,
-        VK_INSERT, VK_LEFT, VK_MENU, VK_NEXT, VK_PRIOR, VK_RETURN, VK_RIGHT, VK_SHIFT, VK_TAB,
-        VK_UP,
+        GetForegroundWindow, GetKeyboardLayout, GetWindowThreadProcessId, ToUnicodeEx, VK_BACK,
+        VK_CONTROL, VK_DELETE, VK_DOWN, VK_END, VK_ESCAPE, VK_F1, VK_F24, VK_HOME, VK_INSERT,
+        VK_LEFT, VK_MENU, VK_NEXT, VK_NUMPAD0, VK_NUMPAD9, VK_PRIOR, VK_RETURN, VK_RIGHT, VK_SHIFT,
+        VK_TAB, VK_UP,
     },
 };
 
@@ -87,6 +89,109 @@ impl From<&ControlKeyState> for KeyModifiers {
     }
 }
 
+enum CharCase {
+    LowerCase,
+    UpperCase,
+}
+
+fn try_ensure_char_case(ch: char, desired_case: CharCase) -> char {
+    match desired_case {
+        CharCase::LowerCase if ch.is_uppercase() => {
+            let mut iter = ch.to_lowercase();
+            // Unwrap is safe; iterator yields one or more chars.
+            let ch_lower = iter.next().unwrap();
+            if iter.next() == None {
+                ch_lower
+            } else {
+                ch
+            }
+        }
+        CharCase::UpperCase if ch.is_lowercase() => {
+            let mut iter = ch.to_uppercase();
+            // Unwrap is safe; iterator yields one or more chars.
+            let ch_upper = iter.next().unwrap();
+            if iter.next() == None {
+                ch_upper
+            } else {
+                ch
+            }
+        }
+        _ => ch,
+    }
+}
+
+// Attempts to return the character for a key event accounting for the user's keyboard layout.
+// The returned character (if any) is capitalized (if applicable) based on shift and capslock state.
+// Returns None if the key doesn't map to a character or if it is a dead key.
+// We use the *currently* active keyboard layout (if it can be determined). This layout may not
+// correspond to the keyboard layout that was active when the user typed their input, since console
+// applications get their input asynchronously from the terminal. By the time a console application
+// can process a key input, the user may have changed the active layout. In this case, the character
+// returned might not correspond to what the user expects, but there is no way for a console
+// application to know what the keyboard layout actually was for a key event, so this is our best
+// effort. If a console application processes input in a timely fashion, then it is unlikely that a
+// user has time to change their keyboard layout before a key event is processed.
+fn get_char_for_key(key_event: &KeyEventRecord) -> Option<char> {
+    let virtual_key_code = key_event.virtual_key_code as u32;
+    let virtual_scan_code = key_event.virtual_scan_code as u32;
+    let key_state = [0u8; 256];
+    let mut utf16_buf = [0u16, 16];
+    let dont_change_kernel_keyboard_state = 0x4;
+
+    // Best-effort attempt at determining the currently active keyboard layout.
+    // At the time of writing, this works for a console application running in Windows Terminal, but
+    // doesn't work under a Conhost terminal. For Conhost, the window handle returned by
+    // GetForegroundWindow() does not appear to actually be the foreground window which has the
+    // keyboard layout associated with it (or perhaps it is, but also has special protection that
+    // doesn't allow us to query it).
+    // When this determination fails, the returned keyboard layout handle will be null, which is an
+    // acceptable input for ToUnicodeEx, as that argument is optional. In this case ToUnicodeEx
+    // appears to use the keyboard layout associated with the current thread, which will be the
+    // layout that was inherited when the console application started (or possibly when the current
+    // thread was spawned). This is then unfortunately not updated when the user changes their
+    // keyboard layout in the terminal, but it's what we get.
+    let active_keyboard_layout = unsafe {
+        let foreground_window = GetForegroundWindow();
+        let foreground_thread = GetWindowThreadProcessId(foreground_window, std::ptr::null_mut());
+        GetKeyboardLayout(foreground_thread)
+    };
+
+    let ret = unsafe {
+        ToUnicodeEx(
+            virtual_key_code,
+            virtual_scan_code,
+            key_state.as_ptr(),
+            utf16_buf.as_mut_ptr(),
+            utf16_buf.len() as i32,
+            dont_change_kernel_keyboard_state,
+            active_keyboard_layout,
+        )
+    };
+
+    // -1 indicates a dead key.
+    // 0 indicates no character for this key.
+    if ret < 1 {
+        return None;
+    }
+
+    let mut ch_iter = std::char::decode_utf16(utf16_buf.into_iter().take(ret as usize));
+    let mut ch = ch_iter.next()?.ok()?;
+    if ch_iter.next() != None {
+        // Key doesn't map to a single char.
+        return None;
+    }
+
+    let is_shift_pressed = key_event.control_key_state.has_state(SHIFT_PRESSED);
+    let is_capslock_on = key_event.control_key_state.has_state(CAPSLOCK_ON);
+    let desired_case = if is_shift_pressed ^ is_capslock_on {
+        CharCase::UpperCase
+    } else {
+        CharCase::LowerCase
+    };
+    ch = try_ensure_char_case(ch, desired_case);
+    Some(ch)
+}
+
 fn parse_key_event_record(key_event: &KeyEventRecord) -> Option<WindowsKeyEvent> {
     let modifiers = KeyModifiers::from(&key_event.control_key_state);
     let virtual_key_code = key_event.virtual_key_code as i32;
@@ -110,6 +215,14 @@ fn parse_key_event_record(key_event: &KeyEventRecord) -> Option<WindowsKeyEvent>
                 return Some(WindowsKeyEvent::KeyEvent(key_event));
             }
         }
+    }
+
+    // Don't generate events for numpad key presses when they're producing Alt codes.
+    let is_numpad_numeric_key = (VK_NUMPAD0..=VK_NUMPAD9).contains(&virtual_key_code);
+    let is_only_alt_modifier = modifiers.contains(KeyModifiers::ALT)
+        && !modifiers.contains(KeyModifiers::SHIFT | KeyModifiers::CONTROL);
+    if is_only_alt_modifier && is_numpad_numeric_key {
+        return None;
     }
 
     if !key_event.key_down {
@@ -137,22 +250,13 @@ fn parse_key_event_record(key_event: &KeyEventRecord) -> Option<WindowsKeyEvent>
         _ => {
             let utf16 = key_event.u_char;
             match utf16 {
-                0 => {
-                    // Unsupported key combination.
-                    None
-                }
-                control_code @ 0x01..=0x1f if modifiers.contains(KeyModifiers::CONTROL) => {
-                    // Terminal emulators encode the key combinations CTRL+A through CTRL+Z, CTRL+[
-                    // CTRL+\, CTRL+], CTRL+^, and CTRL+_ as control codes 0x01 through 0x1f
-                    // respectively.
-                    // We map them back to character codes before we return the key event. Other
-                    // keys that produce control codes (ESC, TAB, ENTER, BACKSPACE) are handled
-                    // above by their virtual key codes and distinguished that way.
-                    let mut ch = (control_code + 64) as u8 as char;
-                    if !modifiers.contains(KeyModifiers::SHIFT) {
-                        ch.make_ascii_lowercase();
-                    }
-                    Some(KeyCode::Char(ch))
+                0x00..=0x1f => {
+                    // Some key combinations generate either no u_char value or generate control
+                    // codes. To deliver back a KeyCode::Char(...) event we want to know which
+                    // character the key normally maps to on the user's keyboard layout.
+                    // The keys that intentionally generate control codes (ESC, ENTER, TAB, etc.)
+                    // are handled by their virtual key codes above.
+                    get_char_for_key(key_event).map(KeyCode::Char)
                 }
                 surrogate @ 0xD800..=0xDFFF => {
                     return Some(WindowsKeyEvent::Surrogate(surrogate));

--- a/src/event/sys/windows/parse.rs
+++ b/src/event/sys/windows/parse.rs
@@ -5,7 +5,8 @@ use winapi::um::{
     },
     winuser::{
         VK_BACK, VK_CONTROL, VK_DELETE, VK_DOWN, VK_END, VK_ESCAPE, VK_F1, VK_F24, VK_HOME,
-        VK_INSERT, VK_LEFT, VK_MENU, VK_NEXT, VK_PRIOR, VK_RETURN, VK_RIGHT, VK_SHIFT, VK_UP,
+        VK_INSERT, VK_LEFT, VK_MENU, VK_NEXT, VK_PRIOR, VK_RETURN, VK_RIGHT, VK_SHIFT, VK_TAB,
+        VK_UP,
     },
 };
 
@@ -75,6 +76,8 @@ fn parse_key_event_record(key_event: &KeyEventRecord) -> Option<KeyEvent> {
         VK_END => Some(KeyCode::End),
         VK_DELETE => Some(KeyCode::Delete),
         VK_INSERT => Some(KeyCode::Insert),
+        VK_TAB if modifiers.contains(KeyModifiers::SHIFT) => Some(KeyCode::BackTab),
+        VK_TAB => Some(KeyCode::Tab),
         _ => {
             // Modifier Keys (Ctrl, Alt, Shift) Support
             let character_raw = key_event.u_char;
@@ -109,13 +112,7 @@ fn parse_key_event_record(key_event: &KeyEventRecord) -> Option<KeyEvent> {
                     }
                 }
 
-                if modifiers.contains(KeyModifiers::SHIFT) && character == '\t' {
-                    Some(KeyCode::BackTab)
-                } else if character == '\t' {
-                    Some(KeyCode::Tab)
-                } else {
-                    Some(KeyCode::Char(character))
-                }
+                Some(KeyCode::Char(character))
             } else {
                 std::char::from_u32(character_raw as u32).map(KeyCode::Char)
             }


### PR DESCRIPTION
Hi

I was playing around with tui and crossterm and ran into issue #561, so I thought I'd dig in and fix it. While I was there, I then also decided to fix some other issues around missing or inaccurate events for certain key combinations (#536, #643).

The unicode issue turns out to be fairly straightforward; we need to parse surrogate pairs (for Windows Terminal) and handle alt codes (for Conhost).

The missing/inaccurate keys issue turns out to be much tougher. See commit f52347c for details. I don't think it's possible to solve correctly in general -- the available data and APIs are simply insufficient. The solution I propose makes a best-effort attempt at providing an accurate event for all key combinations.
This works as one would want in Windows Terminal, but is unreliable in Conhost if users change their keyboard layout. I could not find any reliable way to detect the active keyboard layout under a Conhost terminal. I decided to settle for a partial solution (works when not changing keyboard layouts) rather than hacking together an unreliable solution.
Regarding a hacky, unreliable solution: It _is_ actually possible to find a window handle for a Conhost terminal that can be queried for the active keyboard layout, but no API directly offers such a handle. I found this out by looking through process/window/thread handles in Spy++ for a Conhost terminal session. Enumerating and digging through attached console processes and their window handles seemed very brittle to me, so I didn't pursue it further. We could dig more in that direction if you think it's worthwhile to have that for Conhost terminals, even if it could break for any future change to the OS/Conhost infrastructure.