### PR TITLE
Use internal doc-links and add a new link

### DIFF
--- a/src/event/stream.rs
+++ b/src/event/stream.rs
@@ -24,7 +24,7 @@ use super::{
 /// **This type is not available by default. You have to use the `event-stream` feature flag
 /// to make it available.**
 ///
-/// It implements the [`futures::stream::Stream`](https://docs.rs/futures/0.3.1/futures/stream/trait.Stream.html)
+/// It implements the [Stream](futures_core::stream::Stream)
 /// trait and allows you to receive `Event`s with [`async-std`](https://crates.io/crates/async-std)
 /// or [`tokio`](https://crates.io/crates/tokio) crates.
 ///

--- a/src/event/stream.rs
+++ b/src/event/stream.rs
@@ -25,7 +25,7 @@ use super::{
 /// to make it available.**
 ///
 /// It implements the [Stream](futures_core::stream::Stream)
-/// trait and allows you to receive `Event`s with [`async-std`](https://crates.io/crates/async-std)
+/// trait and allows you to receive [`Event`]s with [`async-std`](https://crates.io/crates/async-std)
 /// or [`tokio`](https://crates.io/crates/tokio) crates.
 ///
 /// Check the [examples](https://github.com/crossterm-rs/crossterm/tree/master/examples) folder to see how to use

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -16,7 +16,7 @@ macro_rules! csi {
 ///
 /// # Arguments
 ///
-/// - [std::io::Writer](https://doc.rust-lang.org/std/io/trait.Write.html)
+/// - [std::io::Writer](std::io::Write)
 ///
 ///     ANSI escape codes are written on the given 'writer', after which they are flushed.
 ///
@@ -70,7 +70,7 @@ macro_rules! queue {
 ///
 /// # Arguments
 ///
-/// - [std::io::Writer](https://doc.rust-lang.org/std/io/trait.Write.html)
+/// - [std::io::Writer](std::io::Write)
 ///
 ///     ANSI escape codes are written on the given 'writer', after which they are flushed.
 ///


### PR DESCRIPTION
- The link to futures:stream::Stream can now be followed when offline.
- The std link now links to the current rust toolchain in use. (e.g.
  https://doc.rust-lang.org/nightly/.. if cargo +nightly doc. Not that
  this really matters for nightly specifically, in this case.)

Additionally, the links are now "upgraded" along with versions. The
updated futures-link pointed to a yanked version, for example.