### PR TITLE
Fix escape codes for git-bash on 3rd party terms

### DIFF
--- a/src/ansi_support.rs
+++ b/src/ansi_support.rs
@@ -38,8 +38,8 @@ pub fn supports_ansi() -> bool {
         // so when we try to enable the ANSI-flag for Windows this won't work.
         // Because of that we should check first if the TERM-variable is set
         // and see if the current terminal is a terminal who does support ANSI.
-        let supported = std::env::var("TERM").map_or(false, |term| term != "dumb")
-            || enable_vt_processing().is_ok();
+        let supported = enable_vt_processing().is_ok()
+            || std::env::var("TERM").map_or(false, |term| term != "dumb");
 
         SUPPORTS_ANSI_ESCAPE_CODES.store(supported, Ordering::SeqCst);
     });


### PR DESCRIPTION
- Fix ansi escape codes not being handled properly for git-bash when
  running terminal emulators other than the included mingw terminal
- ENABLE_VIRTUAL_TERMINAL_PROCESSING is necessary for terminal emulators
  other than the included
- Switching around the OR always tries to enable it, but if it doesn't
  work still reports ansi support depending on the `TERM` envvar
- This should fix issue #656