### PR TITLE
remove stray println in color serialization

### DIFF
--- a/src/style/types/color.rs
+++ b/src/style/types/color.rs
@@ -240,7 +240,6 @@ impl serde::ser::Serialize for Color {
         };
 
         if str == "" {
-            println!("color: {:?}", self);
             match *self {
                 Color::AnsiValue(value) => {
                     return serializer.serialize_str(&format!("ansi_({})", value));


### PR DESCRIPTION
See description.

Further question:
The `rgb_(a,b,c)` format is kinda weird, and non-standard. would you be open to PR to support ser/deser to the more standard hex format (`#RGB`)? I would suggest having deser support both, and serialization switch to the hex format (perhaps feature flagged).