### PR TITLE
Fix some broken links in docs

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -20,7 +20,7 @@
 //! ## Mouse Events
 //!
 //! Mouse events are not enabled by default. You have to enable them with the
-//! [`EnableMouseCapture`](struct.EnableMouseCapture.html) command. See [Command API](./index.html#command-api)
+//! [`EnableMouseCapture`](struct.EnableMouseCapture.html) command. See [Command API](../index.html#command-api)
 //! for more information.
 //!
 //! ## Examples

--- a/src/event.rs
+++ b/src/event.rs
@@ -15,7 +15,7 @@
 //! * use the [`read`](fn.read.html) & [`poll`](fn.poll.html) functions on any, but same, thread
 //! * or the [`EventStream`](struct.EventStream.html).
 //!
-//! **Make sure to enable [raw mode](./terminal/index.html#raw-mode) in order for keyboard events to work properly**
+//! **Make sure to enable [raw mode](../terminal/index.html#raw-mode) in order for keyboard events to work properly**
 //!
 //! ## Mouse Events
 //!


### PR DESCRIPTION
This fixes #649. The broken links were due to typos introduced in #639 (replaced `..` with `.`). I checked the links both browsing with `cargo doc --open` and with a local web server.