### PR TITLE
Add support for other underline types and the ability to color them

### DIFF
--- a/examples/interactive-demo/src/test/attribute.rs
+++ b/examples/interactive-demo/src/test/attribute.rs
@@ -8,6 +8,10 @@ const ATTRIBUTES: [(style::Attribute, style::Attribute); 6] = [
     (style::Attribute::Bold, style::Attribute::NormalIntensity),
     (style::Attribute::Italic, style::Attribute::NoItalic),
     (style::Attribute::Underlined, style::Attribute::NoUnderline),
+    (style::Attribute::DoubleUnderlined, style::Attribute::NoUnderline),
+    (style::Attribute::Undercurled, style::Attribute::NoUnderline),
+    (style::Attribute::Underdotted, style::Attribute::NoUnderline),
+    (style::Attribute::Underdashed, style::Attribute::NoUnderline),
     (style::Attribute::Reverse, style::Attribute::NoReverse),
     (
         style::Attribute::CrossedOut,

--- a/src/style.rs
+++ b/src/style.rs
@@ -217,6 +217,25 @@ impl Command for SetBackgroundColor {
     }
 }
 
+/// A command that sets the the underline color.
+///
+/// See [`Color`](enum.Color.html) for more info.
+///
+/// [`SetColors`](struct.SetColors.html) can also be used to set both the foreground and background
+/// color with one command.
+///
+/// # Notes
+///
+/// Commands must be executed/queued for execution otherwise they do nothing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SetUnderlineColor(pub Color);
+
+impl Command for SetUnderlineColor {
+    fn write_ansi(&self, f: &mut impl fmt::Write) -> fmt::Result {
+        write!(f, csi!("{}m"), Colored::UnderlineColor(self.0))
+    }
+}
+
 /// A command that optionally sets the foreground and/or background color.
 ///
 /// For example:
@@ -337,6 +356,11 @@ impl<D: Display> Command for PrintStyledContent<D> {
         }
         if let Some(fg) = style.foreground_color {
             execute_fmt(f, SetForegroundColor(fg)).map_err(|_| fmt::Error)?;
+            reset_foreground = true;
+        }
+
+        if let Some(ul) = style.underline_color {
+            execute_fmt(f, SetUnderlineColor(ul)).map_err(|_| fmt::Error)?;
             reset_foreground = true;
         }
 

--- a/src/style/content_style.rs
+++ b/src/style/content_style.rs
@@ -11,6 +11,8 @@ pub struct ContentStyle {
     pub foreground_color: Option<Color>,
     /// The background color.
     pub background_color: Option<Color>,
+    /// The underline color.
+    pub underline_color: Option<Color>,
     /// List of attributes.
     pub attributes: Attributes,
 }

--- a/src/style/stylize.rs
+++ b/src/style/stylize.rs
@@ -17,7 +17,7 @@ macro_rules! stylize_method {
             }
         }
     };
-    ($method_name_fg:ident, $method_name_bg:ident Color::$color:ident) => {
+    ($method_name_fg:ident, $method_name_bg:ident, $method_name_ul:ident Color::$color:ident) => {
         calculated_docs! {
             #[doc = concat!(
                 "Sets the foreground color to [`",
@@ -39,6 +39,17 @@ macro_rules! stylize_method {
             )]
             fn $method_name_bg(self) -> Self::Styled {
                 self.on(Color::$color)
+            }
+
+            #[doc = concat!(
+                "Sets the underline color to [`",
+                stringify!($color),
+                "`](Color::",
+                stringify!($color),
+                ")."
+            )]
+            fn $method_name_ul(self) -> Self::Styled {
+                self.above(Color::$color)
             }
         }
     };
@@ -77,6 +88,13 @@ pub trait Stylize: Sized {
         styled
     }
 
+    /// Sets the underline color.
+    fn above(self, color: Color) -> Self::Styled {
+        let mut styled = self.stylize();
+        styled.as_mut().underline_color = Some(color);
+        styled
+    }
+
     /// Styles the content with the attribute.
     fn attribute(self, attr: Attribute) -> Self::Styled {
         let mut styled = self.stylize();
@@ -96,22 +114,22 @@ pub trait Stylize: Sized {
     stylize_method!(hidden Attribute::Hidden);
     stylize_method!(crossed_out Attribute::CrossedOut);
 
-    stylize_method!(black, on_black Color::Black);
-    stylize_method!(dark_grey, on_dark_grey Color::DarkGrey);
-    stylize_method!(red, on_red Color::Red);
-    stylize_method!(dark_red, on_dark_red Color::DarkRed);
-    stylize_method!(green, on_green Color::Green);
-    stylize_method!(dark_green, on_dark_green Color::DarkGreen);
-    stylize_method!(yellow, on_yellow Color::Yellow);
-    stylize_method!(dark_yellow, on_dark_yellow Color::DarkYellow);
-    stylize_method!(blue, on_blue Color::Blue);
-    stylize_method!(dark_blue, on_dark_blue Color::DarkBlue);
-    stylize_method!(magenta, on_magenta Color::Magenta);
-    stylize_method!(dark_magenta, on_dark_magenta Color::DarkMagenta);
-    stylize_method!(cyan, on_cyan Color::Cyan);
-    stylize_method!(dark_cyan, on_dark_cyan Color::DarkCyan);
-    stylize_method!(white, on_white Color::White);
-    stylize_method!(grey, on_grey Color::Grey);
+    stylize_method!(black, on_black, above_black Color::Black);
+    stylize_method!(dark_grey, on_dark_grey, above_dark_grey Color::DarkGrey);
+    stylize_method!(red, on_red, above_red Color::Red);
+    stylize_method!(dark_red, on_dark_red, above_dark_red Color::DarkRed);
+    stylize_method!(green, on_green, above_green Color::Green);
+    stylize_method!(dark_green, on_dark_green, above_dark_green Color::DarkGreen);
+    stylize_method!(yellow, on_yellow, above_yellow Color::Yellow);
+    stylize_method!(dark_yellow, on_dark_yellow, above_dark_yellow Color::DarkYellow);
+    stylize_method!(blue, on_blue, above_blue Color::Blue);
+    stylize_method!(dark_blue, on_dark_blue, above_dark_blue Color::DarkBlue);
+    stylize_method!(magenta, on_magenta, above_magenta Color::Magenta);
+    stylize_method!(dark_magenta, on_dark_magenta, above_dark_magenta Color::DarkMagenta);
+    stylize_method!(cyan, on_cyan, above_cyan Color::Cyan);
+    stylize_method!(dark_cyan, on_dark_cyan, above_dark_cyan Color::DarkCyan);
+    stylize_method!(white, on_white, above_white Color::White);
+    stylize_method!(grey, on_grey, above_grey Color::Grey);
 }
 
 macro_rules! impl_stylize_for_display {

--- a/src/style/stylize.rs
+++ b/src/style/stylize.rs
@@ -49,7 +49,7 @@ macro_rules! stylize_method {
                 ")."
             )]
             fn $method_name_ul(self) -> Self::Styled {
-                self.above(Color::$color)
+                self.underline(Color::$color)
             }
         }
     };
@@ -89,7 +89,7 @@ pub trait Stylize: Sized {
     }
 
     /// Sets the underline color.
-    fn above(self, color: Color) -> Self::Styled {
+    fn underline(self, color: Color) -> Self::Styled {
         let mut styled = self.stylize();
         styled.as_mut().underline_color = Some(color);
         styled
@@ -114,22 +114,22 @@ pub trait Stylize: Sized {
     stylize_method!(hidden Attribute::Hidden);
     stylize_method!(crossed_out Attribute::CrossedOut);
 
-    stylize_method!(black, on_black, above_black Color::Black);
-    stylize_method!(dark_grey, on_dark_grey, above_dark_grey Color::DarkGrey);
-    stylize_method!(red, on_red, above_red Color::Red);
-    stylize_method!(dark_red, on_dark_red, above_dark_red Color::DarkRed);
-    stylize_method!(green, on_green, above_green Color::Green);
-    stylize_method!(dark_green, on_dark_green, above_dark_green Color::DarkGreen);
-    stylize_method!(yellow, on_yellow, above_yellow Color::Yellow);
-    stylize_method!(dark_yellow, on_dark_yellow, above_dark_yellow Color::DarkYellow);
-    stylize_method!(blue, on_blue, above_blue Color::Blue);
-    stylize_method!(dark_blue, on_dark_blue, above_dark_blue Color::DarkBlue);
-    stylize_method!(magenta, on_magenta, above_magenta Color::Magenta);
-    stylize_method!(dark_magenta, on_dark_magenta, above_dark_magenta Color::DarkMagenta);
-    stylize_method!(cyan, on_cyan, above_cyan Color::Cyan);
-    stylize_method!(dark_cyan, on_dark_cyan, above_dark_cyan Color::DarkCyan);
-    stylize_method!(white, on_white, above_white Color::White);
-    stylize_method!(grey, on_grey, above_grey Color::Grey);
+    stylize_method!(black, on_black, underline_black Color::Black);
+    stylize_method!(dark_grey, on_dark_grey, underline_dark_grey Color::DarkGrey);
+    stylize_method!(red, on_red, underline_red Color::Red);
+    stylize_method!(dark_red, on_dark_red, underline_dark_red Color::DarkRed);
+    stylize_method!(green, on_green, underline_green Color::Green);
+    stylize_method!(dark_green, on_dark_green, underline_dark_green Color::DarkGreen);
+    stylize_method!(yellow, on_yellow, underline_yellow Color::Yellow);
+    stylize_method!(dark_yellow, on_dark_yellow, underline_dark_yellow Color::DarkYellow);
+    stylize_method!(blue, on_blue, underline_blue Color::Blue);
+    stylize_method!(dark_blue, on_dark_blue, underline_dark_blue Color::DarkBlue);
+    stylize_method!(magenta, on_magenta, underline_magenta Color::Magenta);
+    stylize_method!(dark_magenta, on_dark_magenta, underline_dark_magenta Color::DarkMagenta);
+    stylize_method!(cyan, on_cyan, underline_cyan Color::Cyan);
+    stylize_method!(dark_cyan, on_dark_cyan, underline_dark_cyan Color::DarkCyan);
+    stylize_method!(white, on_white, underline_white Color::White);
+    stylize_method!(grey, on_grey, underline_grey Color::Grey);
 }
 
 macro_rules! impl_stylize_for_display {

--- a/src/style/types/attribute.rs
+++ b/src/style/types/attribute.rs
@@ -100,6 +100,19 @@ Attribute! {
     Italic = 3,
     /// Underlines the text.
     Underlined = 4,
+
+    /// A parsec-crossterm extension.
+    /// Double underlines the text.
+    DoubleUnderlined = 2,
+    /// A parsec-crossterm extension.
+    /// Undercurls the text.
+    Undercurled = 3,
+    /// A parsec-crossterm extension.
+    /// Underdots the text.
+    Underdotted = 4,
+    /// A parsec-crossterm extension.
+    /// Underdashes the text.
+    Underdashed = 5,
     /// Makes the text blinking (< 150 per minute).
     SlowBlink = 5,
     /// Makes the text blinking (>= 150 per minute).
@@ -163,7 +176,10 @@ impl Attribute {
     /// Returns the SGR attribute value.
     ///
     /// See <https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_parameters>
-    pub fn sgr(self) -> i16 {
-        SGR[self as usize]
+    pub fn sgr(self) -> String {
+        if (self as usize) > 4 && (self as usize) < 9 {
+            return "4:".to_string() + SGR[self as usize].to_string().as_str()
+        }
+        SGR[self as usize].to_string()
     }
 }

--- a/src/style/types/attribute.rs
+++ b/src/style/types/attribute.rs
@@ -101,18 +101,16 @@ Attribute! {
     /// Underlines the text.
     Underlined = 4,
 
-    /// A parsec-crossterm extension.
+    // Other types of underlining
     /// Double underlines the text.
     DoubleUnderlined = 2,
-    /// A parsec-crossterm extension.
     /// Undercurls the text.
     Undercurled = 3,
-    /// A parsec-crossterm extension.
     /// Underdots the text.
     Underdotted = 4,
-    /// A parsec-crossterm extension.
     /// Underdashes the text.
     Underdashed = 5,
+
     /// Makes the text blinking (< 150 per minute).
     SlowBlink = 5,
     /// Makes the text blinking (>= 150 per minute).

--- a/src/style/types/colored.rs
+++ b/src/style/types/colored.rs
@@ -16,6 +16,8 @@ pub enum Colored {
     ForegroundColor(Color),
     /// A background color.
     BackgroundColor(Color),
+    /// An underline color.
+    UnderlineColor(Color),
 }
 
 impl Colored {
@@ -39,16 +41,18 @@ impl Colored {
     ///
     /// See also: [`Color::parse_ansi`].
     pub fn parse_ansi(ansi: &str) -> Option<Self> {
-        use Colored::{BackgroundColor, ForegroundColor};
+        use Colored::{BackgroundColor, ForegroundColor, UnderlineColor};
 
         let values = &mut ansi.split(';');
 
         let output = match parse_next_u8(values)? {
             38 => return Color::parse_ansi_iter(values).map(ForegroundColor),
             48 => return Color::parse_ansi_iter(values).map(BackgroundColor),
+            58 => return Color::parse_ansi_iter(values).map(UnderlineColor),
 
             39 => ForegroundColor(Color::Reset),
             49 => BackgroundColor(Color::Reset),
+            59 => UnderlineColor(Color::Reset),
 
             _ => return None,
         };
@@ -79,6 +83,14 @@ impl fmt::Display for Colored {
                     return f.write_str("49");
                 } else {
                     f.write_str("48;")?;
+                    color = new_color;
+                }
+            }
+            Colored::UnderlineColor(new_color) => {
+                if new_color == Color::Reset {
+                    return f.write_str("59");
+                } else {
+                    f.write_str("58;")?;
                     color = new_color;
                 }
             }

--- a/src/style/types/colors.rs
+++ b/src/style/types/colors.rs
@@ -63,6 +63,10 @@ impl From<Colored> for Colors {
                 foreground: None,
                 background: Some(color),
             },
+            Colored::UnderlineColor(color) => Colors {
+                foreground: None,
+                background: Some(color),
+            }
         }
     }
 }


### PR DESCRIPTION
This PR aims to extend the attribute system to allow for more types of attributes, specifically, double, curled, dotted, and dashed underlines. It also aims to add another color to styles, which would be applied to the underlines.

The new attributes, which can be used like any other, are:
```
DoubleUnderlined = 2
Undercurled = 3
Underdotted = 4
Underdashed = 5
```
The numbers here represent what number should be placed on `\x1b[4:{}m`, which is the control sequence that is becoming common for other types of underlining.

`ContentStyle` now has another member: `underline_color`. It works exactly like the other 2 colors, you can use RGB, terminal colors, etc.

Here's an example of this PR being used:
```rust
use crossterm::{
    self,
    ExecutableCommand,
    style::{
        Color, PrintStyledContent, Attribute, ContentStyle, StyledContent,
    }
};

use std::io::stdout;

fn main() {
    let mut stdout = stdout();

    let style = ContentStyle {
        foreground_color: Some(Color::Red),
        background_color: None,
        underline_color: Some(Color::Blue),
        attributes: Attribute::Underdashed.into(),
    };

    let test = StyledContent::new(style, "my test string :)");

    stdout.execute(PrintStyledContent(test)).unwrap();
}
```
In my terminal (kitty), this outputs:
![image](https://user-images.githubusercontent.com/91404038/172029177-e965b6e4-d7d8-4aaf-afe9-c4c9414fcdf7.png)

This PR does not currently take windows into consideration, as I'm not really sure that windows terminals even support these features

One other thing that should maybe be considered is a configuration option to enable or disable these features when using this package, like `styled-underlines`, or something like that.

I haven't yet touched the documentation, since I don't really know if this PR will be considered. If it is under consideration, I might make changes to the docs.