### PR TITLE
Fix zero terminal sizes being treated as ok in Unix

### DIFF
--- a/src/terminal/sys/unix.rs
+++ b/src/terminal/sys/unix.rs
@@ -40,10 +40,11 @@ pub(crate) fn size() -> Result<(u16, u16)> {
     };
 
     if wrap_with_result(unsafe { ioctl(fd, TIOCGWINSZ.into(), &mut size) }).is_ok() {
-        Ok((size.ws_col, size.ws_row))
-    } else {
-        tput_size().ok_or_else(|| std::io::Error::last_os_error().into())
+        if size.ws_col != 0 && size.ws_row != 0 {
+            return Ok((size.ws_col, size.ws_row))
+        }
     }
+    tput_size().ok_or_else(|| std::io::Error::last_os_error().into())
 }
 
 pub(crate) fn enable_raw_mode() -> Result<()> {

--- a/src/terminal/sys/unix.rs
+++ b/src/terminal/sys/unix.rs
@@ -41,7 +41,7 @@ pub(crate) fn size() -> Result<(u16, u16)> {
 
     if wrap_with_result(unsafe { ioctl(fd, TIOCGWINSZ.into(), &mut size) }).is_ok() {
         if size.ws_col != 0 && size.ws_row != 0 {
-            return Ok((size.ws_col, size.ws_row))
+            return Ok((size.ws_col, size.ws_row));
         }
     }
     tput_size().ok_or_else(|| std::io::Error::last_os_error().into())


### PR DESCRIPTION
When using the builtin debugging terminal of IntelliJ on Linux (haven't tried on Windows) `terminal::size()` reports `Ok((0, 0))`.

Apparently in the following piece of code, `ioctl` yields a size of `0, 0` under these circumstances:

https://github.com/crossterm-rs/crossterm/blob/21155716e2eedd5ba8ab97168e5eed7cd50d2ad8/src/terminal/sys/unix.rs#L42-L47

This pr fixes this by treating a zero width or height as an error condition with the fallback to `tput_size()`.
`tput_size()` seems to consistently yield the correct results for the IntelliJ debugging terminal.