### PR TITLE
Add support for cursor/arrow keys in application mode

### DIFF
--- a/src/event/sys/unix/parse.rs
+++ b/src/event/sys/unix/parse.rs
@@ -44,6 +44,12 @@ pub(crate) fn parse_event(buffer: &[u8], input_available: bool) -> Result<Option
                             Ok(None)
                         } else {
                             match buffer[2] {
+                                b'D' => Ok(Some(InternalEvent::Event(Event::Key(KeyCode::Left.into())))),
+                                b'C' => Ok(Some(InternalEvent::Event(Event::Key(KeyCode::Right.into())))),
+                                b'A' => Ok(Some(InternalEvent::Event(Event::Key(KeyCode::Up.into())))),
+                                b'B' => Ok(Some(InternalEvent::Event(Event::Key(KeyCode::Down.into())))),
+                                b'H' => Ok(Some(InternalEvent::Event(Event::Key(KeyCode::Home.into())))),
+                                b'F' => Ok(Some(InternalEvent::Event(Event::Key(KeyCode::End.into())))),
                                 // F1-F4
                                 val @ b'P'..=b'S' => Ok(Some(InternalEvent::Event(Event::Key(
                                     KeyCode::F(1 + val - b'P').into(),


### PR DESCRIPTION
A simple change to add support for Home/End and Arrow Keys in application mode (besides the normal mode).

For example, the Arrow Up key can be sent as:

| Normal mode | Application mode |
|-|-|
| ESC [ A | ESC O A |

I discovered the issue when I couldn’t move the cursor in Helix editor using the Blink Shell app on iOS (which seems to always use the application mode).