### PR TITLE
Assure all mouse commands are 0 based and document this.

### DIFF
--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -55,7 +55,7 @@ pub(crate) mod sys;
 /// A command that moves the terminal cursor to the given position (column, row).
 ///
 /// # Notes
-///
+/// * This command is 0 based, meaning 0 is 1.
 /// * Top left cell is represented as `0,0`.
 /// * Commands must be executed/queued for execution otherwise they do nothing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -76,16 +76,14 @@ impl Command for MoveTo {
 /// and moves it to the first column.
 ///
 /// # Notes
-///
-/// Commands must be executed/queued for execution otherwise they do nothing.
+/// * This command is 0 based, meaning 0 is 1.
+/// * Commands must be executed/queued for execution otherwise they do nothing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MoveToNextLine(pub u16);
 
 impl Command for MoveToNextLine {
     fn write_ansi(&self, f: &mut impl fmt::Write) -> fmt::Result {
-        if self.0 != 0 {
-            write!(f, csi!("{}E"), self.0)?;
-        }
+        write!(f, csi!("{}E"), self.0 + 1)?;
         Ok(())
     }
 
@@ -102,16 +100,14 @@ impl Command for MoveToNextLine {
 /// and moves it to the first column.
 ///
 /// # Notes
-///
-/// Commands must be executed/queued for execution otherwise they do nothing.
+/// * This command is 0 based, meaning 0 is 1.
+/// * Commands must be executed/queued for execution otherwise they do nothing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MoveToPreviousLine(pub u16);
 
 impl Command for MoveToPreviousLine {
     fn write_ansi(&self, f: &mut impl fmt::Write) -> fmt::Result {
-        if self.0 != 0 {
-            write!(f, csi!("{}F"), self.0)?;
-        }
+        write!(f, csi!("{}F"), self.0 + 1)?;
         Ok(())
     }
 
@@ -127,16 +123,14 @@ impl Command for MoveToPreviousLine {
 /// A command that moves the terminal cursor to the given column on the current row.
 ///
 /// # Notes
-///
-/// Commands must be executed/queued for execution otherwise they do nothing.
+/// * This command is 0 based, meaning 0 is 1.
+/// * Commands must be executed/queued for execution otherwise they do nothing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MoveToColumn(pub u16);
 
 impl Command for MoveToColumn {
     fn write_ansi(&self, f: &mut impl fmt::Write) -> fmt::Result {
-        if self.0 != 0 {
-            write!(f, csi!("{}G"), self.0)?;
-        }
+        write!(f, csi!("{}G"), self.0 + 1)?;
         Ok(())
     }
 
@@ -149,16 +143,14 @@ impl Command for MoveToColumn {
 /// A command that moves the terminal cursor to the given row on the current column.
 ///
 /// # Notes
-///
-/// Commands must be executed/queued for execution otherwise they do nothing.
+/// * This command is 0 based, meaning 0 is 1.
+/// * Commands must be executed/queued for execution otherwise they do nothing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MoveToRow(pub u16);
 
 impl Command for MoveToRow {
     fn write_ansi(&self, f: &mut impl fmt::Write) -> fmt::Result {
-        if self.0 != 0 {
-            write!(f, csi!("{}d"), self.0)?
-        }
+        write!(f, csi!("{}d"), self.0 + 1)?;
         Ok(())
     }
 
@@ -171,16 +163,14 @@ impl Command for MoveToRow {
 /// A command that moves the terminal cursor a given number of rows up.
 ///
 /// # Notes
-///
-/// Commands must be executed/queued for execution otherwise they do nothing.
+/// * This command is 0 based, meaning 0 is 1.
+/// * Commands must be executed/queued for execution otherwise they do nothing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MoveUp(pub u16);
 
 impl Command for MoveUp {
     fn write_ansi(&self, f: &mut impl fmt::Write) -> fmt::Result {
-        if self.0 != 0 {
-            write!(f, csi!("{}A"), self.0)?;
-        }
+        write!(f, csi!("{}A"), self.0 + 1)?;
         Ok(())
     }
 
@@ -193,16 +183,14 @@ impl Command for MoveUp {
 /// A command that moves the terminal cursor a given number of columns to the right.
 ///
 /// # Notes
-///
-/// Commands must be executed/queued for execution otherwise they do nothing.
+/// * This command is 0 based, meaning 0 is 1.
+/// * Commands must be executed/queued for execution otherwise they do nothing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MoveRight(pub u16);
 
 impl Command for MoveRight {
     fn write_ansi(&self, f: &mut impl fmt::Write) -> fmt::Result {
-        if self.0 != 0 {
-            write!(f, csi!("{}C"), self.0)?;
-        }
+        write!(f, csi!("{}C"), self.0)?;
         Ok(())
     }
 
@@ -215,16 +203,14 @@ impl Command for MoveRight {
 /// A command that moves the terminal cursor a given number of rows down.
 ///
 /// # Notes
-///
-/// Commands must be executed/queued for execution otherwise they do nothing.
+/// * This command is 0 based, meaning 0 is 1.
+/// * Commands must be executed/queued for execution otherwise they do nothing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MoveDown(pub u16);
 
 impl Command for MoveDown {
     fn write_ansi(&self, f: &mut impl fmt::Write) -> fmt::Result {
-        if self.0 != 0 {
-            write!(f, csi!("{}B"), self.0)?;
-        }
+        write!(f, csi!("{}B"), self.0 + 1)?;
         Ok(())
     }
 
@@ -237,16 +223,14 @@ impl Command for MoveDown {
 /// A command that moves the terminal cursor a given number of columns to the left.
 ///
 /// # Notes
-///
-/// Commands must be executed/queued for execution otherwise they do nothing.
+/// * This command is 0 based, meaning 0 is 1.
+/// * Commands must be executed/queued for execution otherwise they do nothing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MoveLeft(pub u16);
 
 impl Command for MoveLeft {
     fn write_ansi(&self, f: &mut impl fmt::Write) -> fmt::Result {
-        if self.0 != 0 {
-            write!(f, csi!("{}D"), self.0)?;
-        }
+        write!(f, csi!("{}D"), self.0 + 1)?;
         Ok(())
     }
 


### PR DESCRIPTION
There is correct confusion about crossterm claiming to be 0-based at one place but being 1-based on other places. This is inconsistent and is addressed in this PR.  This PR assures all functions are 0-based and reverts the changes made in that just ignored 0-arguments.

Fixes: https://github.com/crossterm-rs/crossterm/issues/632
Fixes: https://github.com/crossterm-rs/crossterm/issues/599
Fixes: https://github.com/crossterm-rs/crossterm/issues/683