### PR TITLE
Increase support for kitty enhanced keyboard protocol

### DIFF
--- a/examples/event-match-modifiers.rs
+++ b/examples/event-match-modifiers.rs
@@ -2,7 +2,7 @@
 //!
 //! cargo run --example event-match-modifiers
 
-use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 
 fn match_event(read_event: Event) {
     match read_event {
@@ -10,24 +10,29 @@ fn match_event(read_event: Event) {
         Event::Key(KeyEvent {
             modifiers: KeyModifiers::CONTROL,
             code,
+            ..
         }) => {
             println!("Control + {:?}", code);
         }
         Event::Key(KeyEvent {
             modifiers: KeyModifiers::SHIFT,
             code,
+            ..
         }) => {
             println!("Shift + {:?}", code);
         }
         Event::Key(KeyEvent {
             modifiers: KeyModifiers::ALT,
             code,
+            ..
         }) => {
             println!("Alt + {:?}", code);
         }
 
         // Match on multiple modifiers:
-        Event::Key(KeyEvent { code, modifiers }) => {
+        Event::Key(KeyEvent {
+            code, modifiers, ..
+        }) => {
             if modifiers == (KeyModifiers::ALT | KeyModifiers::SHIFT) {
                 println!("Alt + Shift {:?}", code);
             } else {
@@ -43,21 +48,26 @@ fn main() {
     match_event(Event::Key(KeyEvent {
         modifiers: KeyModifiers::CONTROL,
         code: KeyCode::Char('z'),
+        kind: KeyEventKind::Press,
     }));
     match_event(Event::Key(KeyEvent {
         modifiers: KeyModifiers::SHIFT,
         code: KeyCode::Left,
+        kind: KeyEventKind::Press,
     }));
     match_event(Event::Key(KeyEvent {
         modifiers: KeyModifiers::ALT,
         code: KeyCode::Delete,
+        kind: KeyEventKind::Press,
     }));
     match_event(Event::Key(KeyEvent {
         modifiers: KeyModifiers::ALT | KeyModifiers::SHIFT,
         code: KeyCode::Right,
+        kind: KeyEventKind::Press,
     }));
     match_event(Event::Key(KeyEvent {
         modifiers: KeyModifiers::ALT | KeyModifiers::CONTROL,
         code: KeyCode::Home,
+        kind: KeyEventKind::Press,
     }));
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,9 @@
 //!    - Shape -
 //!      [`SetCursorShape`](cursor/struct.SetCursorShape.html)
 //! - Module [`event`](event/index.html)
+//!   - Keyboard events -
+//!     [`PushKeyboardEnhancementFlags`](event/struct.PushKeyboardEnhancementFlags.html),
+//!     [`PopKeyboardEnhancementFlags`](event/struct.PopKeyboardEnhancementFlags.html)
 //!   - Mouse events - [`EnableMouseCapture`](event/struct.EnableMouseCapture.html),
 //!     [`DisableMouseCapture`](event/struct.DisableMouseCapture.html)
 //! - Module [`style`](style/index.html)


### PR DESCRIPTION
Add parsing of repeat/release key events, and allow sending the CSIs to enable/disable the enhanced keyboard protocol.

See https://sw.kovidgoyal.net/kitty/keyboard-protocol/ for more information.

**Note**: this changes the form of the `KeyEvent` struct.