### PR TITLE
Emit focus events

### DIFF
--- a/examples/event-read.rs
+++ b/examples/event-read.rs
@@ -7,7 +7,10 @@ use std::io::stdout;
 use crossterm::event::poll;
 use crossterm::{
     cursor::position,
-    event::{read, DisableMouseCapture, EnableMouseCapture, Event, KeyCode},
+    event::{
+        read, DisableFocusChange, DisableMouseCapture, EnableFocusChange, EnableMouseCapture,
+        Event, KeyCode,
+    },
     execute,
     terminal::{disable_raw_mode, enable_raw_mode},
     Result,
@@ -15,7 +18,7 @@ use crossterm::{
 use std::time::Duration;
 
 const HELP: &str = r#"Blocking read()
- - Keyboard, mouse and terminal resize events enabled
+ - Keyboard, mouse, focus and terminal resize events enabled
  - Hit "c" to print current cursor position
  - Use Esc to quit
 "#;
@@ -67,13 +70,13 @@ fn main() -> Result<()> {
     enable_raw_mode()?;
 
     let mut stdout = stdout();
-    execute!(stdout, EnableMouseCapture)?;
+    execute!(stdout, EnableFocusChange, EnableMouseCapture)?;
 
     if let Err(e) = print_events() {
         println!("Error: {:?}\r", e);
     }
 
-    execute!(stdout, DisableMouseCapture)?;
+    execute!(stdout, DisableFocusChange, DisableMouseCapture)?;
 
     disable_raw_mode()
 }

--- a/src/event/source/windows.rs
+++ b/src/event/source/windows.rs
@@ -66,6 +66,14 @@ impl EventSource for WindowsEventSource {
                         InputRecord::WindowBufferSizeEvent(record) => {
                             Some(Event::Resize(record.size.x as u16, record.size.y as u16))
                         }
+                        InputRecord::FocusEvent(record) => {
+                            let event = if record.set_focus {
+                                Event::FocusGained
+                            } else {
+                                Event::FocusLost
+                            };
+                            Some(event)
+                        }
                         _ => None,
                     };
 

--- a/src/event/sys/unix/parse.rs
+++ b/src/event/sys/unix/parse.rs
@@ -167,6 +167,8 @@ pub(crate) fn parse_csi(buffer: &[u8]) -> Result<Option<InternalEvent>> {
         })),
         b'M' => return parse_csi_normal_mouse(buffer),
         b'<' => return parse_csi_sgr_mouse(buffer),
+        b'I' => Some(Event::FocusGained),
+        b'O' => Some(Event::FocusLost),
         b'0'..=b'9' => {
             // Numbered escape code.
             if buffer.len() == 3 {
@@ -742,6 +744,14 @@ mod tests {
                 KeyCode::Delete,
                 KeyModifiers::SHIFT
             )))),
+        );
+    }
+
+    #[test]
+    fn test_parse_csi_focus() {
+        assert_eq!(
+            parse_csi(b"\x1B[O").unwrap(),
+            Some(InternalEvent::Event(Event::FocusLost))
         );
     }
 

--- a/src/style.rs
+++ b/src/style.rs
@@ -350,7 +350,6 @@ pub struct SetStyle(pub ContentStyle);
 
 impl Command for SetStyle {
     fn write_ansi(&self, f: &mut impl fmt::Write) -> fmt::Result {
-
         if let Some(bg) = self.0.background_color {
             execute_fmt(f, SetBackgroundColor(bg)).map_err(|_| fmt::Error)?;
         }


### PR DESCRIPTION
I'd like to receive [focus change events](https://terminalguide.namepad.de/mode/p1004/) from crossterm to let me save on loss of focus in [Helix](https://helix-editor.com/).

This adds focus emitting on Unix, though I still need to add documentation and tests.

I wanted to open a PR now as I'm not clear on the best way to support this on Windows. 

**Option 1:** Windows Terminal added these Unix-style focus events in [1.14.186](https://github.com/microsoft/terminal/releases/tag/v1.14.1861.0). That came out a couple weeks ago.  I *think* we'd be able to get those codes since we're enabling virtual terminal processing in Windows, but I don't know enough about the Windows terminal to be sure. I don't see us parsing ansi codes anywhere else in the Windows code, so that makes me worry it's not the case. It would also restrict this to really recent Windows terminal versions.

**Option 2:** Listen for the [FOCUS_EVENT_RECORD](https://docs.microsoft.com/en-us/windows/console/focus-event-record-str) in crossterm-winapi. That would be hacky as that focus record is supposed to be internal. It looks like that's what they're using in Windows Terminal to emit the Unix-style codes, so I'm guessing we could use it.

I'm open to any other options, of course. Thoughts?

P.S. This is the first Rust code I've written, and it was super easy to drop it in and modify the example to try it. Thanks for putting together such a well structured project!