### PR TITLE
Add execute_winapi on SetStyle to fix Windows compilation

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -74,6 +74,7 @@
 
 use std::fmt;
 use std::hash::{Hash, Hasher};
+use std::io;
 use std::time::Duration;
 
 use bitflags::bitflags;

--- a/src/style.rs
+++ b/src/style.rs
@@ -366,6 +366,16 @@ impl Command for SetStyle {
 
         Ok(())
     }
+
+    #[cfg(windows)]
+    fn execute_winapi(&self) -> Result<()> {
+        panic!("tried to execute SetStyle command using WinAPI, use ANSI instead");
+    }
+
+    #[cfg(windows)]
+    fn is_ansi_code_supported(&self) -> bool {
+        true
+    }
 }
 
 /// A command that prints styled content.


### PR DESCRIPTION
Compilation on Windows is failing for me currently with this error:

```
error[E0046]: not all trait items implemented, missing: `execute_winapi`
   --> src\style.rs:351:1
```

I believe https://github.com/crossterm-rs/crossterm/pull/687 introduced the problem.

Reading `execute_fmt`, I believe it'll call `is_ansi_code_supported` on each of the subcommands, so this fix should be good.