### PR TITLE
Add support for functional key codes from kitty keyboard protocol

### DIFF
--- a/examples/event-match-modifiers.rs
+++ b/examples/event-match-modifiers.rs
@@ -45,29 +45,24 @@ fn match_event(read_event: Event) {
 }
 
 fn main() {
-    match_event(Event::Key(KeyEvent {
-        modifiers: KeyModifiers::CONTROL,
-        code: KeyCode::Char('z'),
-        kind: KeyEventKind::Press,
-    }));
-    match_event(Event::Key(KeyEvent {
-        modifiers: KeyModifiers::SHIFT,
-        code: KeyCode::Left,
-        kind: KeyEventKind::Press,
-    }));
-    match_event(Event::Key(KeyEvent {
-        modifiers: KeyModifiers::ALT,
-        code: KeyCode::Delete,
-        kind: KeyEventKind::Press,
-    }));
-    match_event(Event::Key(KeyEvent {
-        modifiers: KeyModifiers::ALT | KeyModifiers::SHIFT,
-        code: KeyCode::Right,
-        kind: KeyEventKind::Press,
-    }));
-    match_event(Event::Key(KeyEvent {
-        modifiers: KeyModifiers::ALT | KeyModifiers::CONTROL,
-        code: KeyCode::Home,
-        kind: KeyEventKind::Press,
-    }));
+    match_event(Event::Key(KeyEvent::new(
+        KeyCode::Char('z'),
+        KeyModifiers::CONTROL,
+    )));
+    match_event(Event::Key(KeyEvent::new(
+        KeyCode::Left,
+        KeyModifiers::SHIFT,
+    )));
+    match_event(Event::Key(KeyEvent::new(
+        KeyCode::Delete,
+        KeyModifiers::ALT,
+    )));
+    match_event(Event::Key(KeyEvent::new(
+        KeyCode::Right,
+        KeyModifiers::ALT | KeyModifiers::SHIFT,
+    )));
+    match_event(Event::Key(KeyEvent::new(
+        KeyCode::Home,
+        KeyModifiers::ALT | KeyModifiers::CONTROL,
+    )));
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -806,8 +806,8 @@ pub enum KeyCode {
     /// Caps Lock key.
     ///
     /// **Note:** this and all following keys can only be read if
-    /// [[`KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES`]] has been enabled with
-    /// [[`PushKeyboardEnhancementFlags`].
+    /// [`KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES`] has been enabled with
+    /// [`PushKeyboardEnhancementFlags`].
     CapsLock,
     /// Scroll Lock key.
     ScrollLock,
@@ -825,7 +825,7 @@ pub enum KeyCode {
     Media(MediaKeyCode),
     /// A modifier key.
     ///
-    /// The [[`KeyboardEnhancementFlags::REPORT_ALL_KEYS_AS_ESCAPE_CODES`]] flag is required to
+    /// The [`KeyboardEnhancementFlags::REPORT_ALL_KEYS_AS_ESCAPE_CODES`] flag is required to
     /// read these keys.
     Modifier(ModifierKeyCode),
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -375,9 +375,9 @@ impl Command for PushKeyboardEnhancementFlags {
 
     #[cfg(windows)]
     fn execute_winapi(&self) -> Result<()> {
-        Err(io::Error::new(
-            io::ErrorKind::Unsupported,
-            "Keyboard progressive enhancement not implemented on Windows.",
+        Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "Keyboard progressive enhancement not implemented for the legacy Windows API.",
         ))
     }
 
@@ -402,9 +402,9 @@ impl Command for PopKeyboardEnhancementFlags {
 
     #[cfg(windows)]
     fn execute_winapi(&self) -> Result<()> {
-        Err(io::Error::new(
-            io::ErrorKind::Unsupported,
-            "Keyboard progressive enhancement not implemented on Windows.",
+        Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "Keyboard progressive enhancement not implemented for the legacy Windows API.",
         ))
     }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -375,8 +375,8 @@ impl Command for PushKeyboardEnhancementFlags {
 
     #[cfg(windows)]
     fn execute_winapi(&self) -> Result<()> {
-        Err(std::io::Error::new(
-            std::io::ErrorKind::Unsupported,
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
             "Keyboard progressive enhancement not implemented for the legacy Windows API.",
         ))
     }
@@ -402,8 +402,8 @@ impl Command for PopKeyboardEnhancementFlags {
 
     #[cfg(windows)]
     fn execute_winapi(&self) -> Result<()> {
-        Err(std::io::Error::new(
-            std::io::ErrorKind::Unsupported,
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
             "Keyboard progressive enhancement not implemented for the legacy Windows API.",
         ))
     }
@@ -557,6 +557,7 @@ bitflags! {
     /// Represents extra state about the key event.
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
     pub struct KeyEventState: u8 {
+        /// The key event origins from the keypad.
         const KEYPAD = 0b0000_0001;
     }
 }
@@ -572,6 +573,9 @@ pub struct KeyEvent {
     /// Kind of event.
     pub kind: KeyEventKind,
     /// Keyboard state.
+    ///
+    /// Only set if [`KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES`] has been enabled with
+    /// [`PushKeyboardEnhancementFlags`].
     pub state: KeyEventState,
 }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -645,6 +645,120 @@ impl Hash for KeyEvent {
     }
 }
 
+/// Represents a key on the keypad (as part of [`KeyCode::Keypad`]).
+#[derive(Debug, PartialOrd, PartialEq, Eq, Clone, Copy, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum KeypadKeyCode {
+    /// A number key.
+    ///
+    /// `KeypadKeyCode::Number(1)` represents F1 key, etc.
+    Number(u8),
+    /// Keypad Decimal (`.`) key.
+    Decimal,
+    /// Keypad Divide (`/`) key.
+    Divide,
+    /// Keypad Multiply (`*`) key.
+    Multiply,
+    /// Keypad Subtract (`-`) key.
+    Subtract,
+    /// Keypad Add (`+`) key.
+    Add,
+    /// Keypad Enter key.
+    Enter,
+    /// Keypad Equal (`=`) key.
+    Equal,
+    /// Keypad Separator key.
+    Separator,
+    /// Keypad Left key.
+    Left,
+    /// Keypad Right key.
+    Right,
+    /// Keypad Up key.
+    Up,
+    /// Keypad Down key.
+    Down,
+    /// Keypad PageUp key.
+    PageUp,
+    /// Keypad PageDown key.
+    PageDown,
+    /// Keypad Home key.
+    Home,
+    /// Keypad End key.
+    End,
+    /// Keypad Insert key.
+    Insert,
+    /// Keypad Delete key.
+    Delete,
+    /// Keypad Begin key.
+    Begin,
+}
+
+/// Represents a media key (as part of [`KeyCode::Media`]).
+#[derive(Debug, PartialOrd, PartialEq, Eq, Clone, Copy, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum MediaKeyCode {
+    /// Play media key.
+    Play,
+    /// Pause media key.
+    Pause,
+    /// Play/Pause media key.
+    PlayPause,
+    /// Reverse media key.
+    Reverse,
+    /// Stop media key.
+    Stop,
+    /// Fast-forward media key.
+    FastForward,
+    /// Rewind media key.
+    Rewind,
+    /// Next-track media key.
+    TrackNext,
+    /// Previous-track media key.
+    TrackPrevious,
+    /// Record media key.
+    Record,
+    /// Lower-volume media key.
+    LowerVolume,
+    /// Raise-volume media key.
+    RaiseVolume,
+    /// Mute media key.
+    MuteVolume,
+}
+
+/// Represents a modifier key (as part of [`KeyCode::Modifier`]).
+#[derive(Debug, PartialOrd, PartialEq, Eq, Clone, Copy, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum ModifierKeyCode {
+    /// Left Shift key.
+    LeftShift,
+    /// Left Control key.
+    LeftControl,
+    /// Left Alt key.
+    LeftAlt,
+    /// Left Super key.
+    LeftSuper,
+    /// Left Hyper key.
+    LeftHyper,
+    /// Left Meta key.
+    LeftMeta,
+    /// Right Shift key.
+    RightShift,
+    /// Right Control key.
+    RightControl,
+    /// Right Alt key.
+    RightAlt,
+    /// Right Super key.
+    RightSuper,
+    /// Right Hyper key.
+    RightHyper,
+    /// Right Meta key.
+    RightMeta,
+    /// Iso Level3 Shift key.
+    IsoLevel3Shift,
+    /// Iso Level5 Shift key.
+    IsoLevel5Shift,
+}
+
 /// Represents a key.
 #[derive(Debug, PartialOrd, PartialEq, Eq, Clone, Copy, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -689,6 +803,31 @@ pub enum KeyCode {
     Null,
     /// Escape key.
     Esc,
+    /// Caps Lock key.
+    ///
+    /// **Note:** this and all following keys can only be read if
+    /// [[`KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES`]] has been enabled with
+    /// [[`PushKeyboardEnhancementFlags`].
+    CapsLock,
+    /// Scroll Lock key.
+    ScrollLock,
+    /// Num Lock key.
+    NumLock,
+    /// Print Screen key.
+    PrintScreen,
+    /// Pause key.
+    Pause,
+    /// Menu key.
+    Menu,
+    /// A key on the keypad.
+    Keypad(KeypadKeyCode),
+    /// A media key.
+    Media(MediaKeyCode),
+    /// A modifier key.
+    ///
+    /// The [[`KeyboardEnhancementFlags::REPORT_ALL_KEYS_AS_ESCAPE_CODES`]] flag is required to
+    /// read these keys.
+    Modifier(ModifierKeyCode),
 }
 
 /// An internal event.

--- a/src/event/sys/unix/parse.rs
+++ b/src/event/sys/unix/parse.rs
@@ -2,8 +2,8 @@ use std::io;
 
 use crate::{
     event::{
-        Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers, MouseButton, MouseEvent,
-        MouseEventKind,
+        Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers, KeypadKeyCode, MediaKeyCode,
+        ModifierKeyCode, MouseButton, MouseEvent, MouseEventKind,
     },
     ErrorKind, Result,
 };
@@ -290,6 +290,97 @@ pub(crate) fn parse_csi_modifier_key_code(buffer: &[u8]) -> Result<Option<Intern
     Ok(Some(InternalEvent::Event(input_event)))
 }
 
+fn translate_functional_key_code(codepoint: u32) -> Option<KeyCode> {
+    match codepoint {
+        57358 => Some(KeyCode::CapsLock),
+        57359 => Some(KeyCode::ScrollLock),
+        57360 => Some(KeyCode::NumLock),
+        57361 => Some(KeyCode::PrintScreen),
+        57362 => Some(KeyCode::Pause),
+        57363 => Some(KeyCode::Menu),
+        57376 => Some(KeyCode::F(13)),
+        57377 => Some(KeyCode::F(14)),
+        57378 => Some(KeyCode::F(15)),
+        57379 => Some(KeyCode::F(16)),
+        57380 => Some(KeyCode::F(17)),
+        57381 => Some(KeyCode::F(18)),
+        57382 => Some(KeyCode::F(19)),
+        57383 => Some(KeyCode::F(20)),
+        57384 => Some(KeyCode::F(21)),
+        57385 => Some(KeyCode::F(22)),
+        57386 => Some(KeyCode::F(23)),
+        57387 => Some(KeyCode::F(24)),
+        57388 => Some(KeyCode::F(25)),
+        57389 => Some(KeyCode::F(26)),
+        57390 => Some(KeyCode::F(27)),
+        57391 => Some(KeyCode::F(28)),
+        57392 => Some(KeyCode::F(29)),
+        57393 => Some(KeyCode::F(30)),
+        57394 => Some(KeyCode::F(31)),
+        57395 => Some(KeyCode::F(32)),
+        57396 => Some(KeyCode::F(33)),
+        57397 => Some(KeyCode::F(34)),
+        57398 => Some(KeyCode::F(35)),
+        57399 => Some(KeyCode::Keypad(KeypadKeyCode::Number(0))),
+        57400 => Some(KeyCode::Keypad(KeypadKeyCode::Number(1))),
+        57401 => Some(KeyCode::Keypad(KeypadKeyCode::Number(2))),
+        57402 => Some(KeyCode::Keypad(KeypadKeyCode::Number(3))),
+        57403 => Some(KeyCode::Keypad(KeypadKeyCode::Number(4))),
+        57404 => Some(KeyCode::Keypad(KeypadKeyCode::Number(5))),
+        57405 => Some(KeyCode::Keypad(KeypadKeyCode::Number(6))),
+        57406 => Some(KeyCode::Keypad(KeypadKeyCode::Number(7))),
+        57407 => Some(KeyCode::Keypad(KeypadKeyCode::Number(8))),
+        57408 => Some(KeyCode::Keypad(KeypadKeyCode::Number(9))),
+        57409 => Some(KeyCode::Keypad(KeypadKeyCode::Decimal)),
+        57410 => Some(KeyCode::Keypad(KeypadKeyCode::Divide)),
+        57411 => Some(KeyCode::Keypad(KeypadKeyCode::Multiply)),
+        57412 => Some(KeyCode::Keypad(KeypadKeyCode::Subtract)),
+        57413 => Some(KeyCode::Keypad(KeypadKeyCode::Add)),
+        57414 => Some(KeyCode::Keypad(KeypadKeyCode::Enter)),
+        57415 => Some(KeyCode::Keypad(KeypadKeyCode::Equal)),
+        57416 => Some(KeyCode::Keypad(KeypadKeyCode::Separator)),
+        57417 => Some(KeyCode::Keypad(KeypadKeyCode::Left)),
+        57418 => Some(KeyCode::Keypad(KeypadKeyCode::Right)),
+        57419 => Some(KeyCode::Keypad(KeypadKeyCode::Up)),
+        57420 => Some(KeyCode::Keypad(KeypadKeyCode::Down)),
+        57421 => Some(KeyCode::Keypad(KeypadKeyCode::PageUp)),
+        57422 => Some(KeyCode::Keypad(KeypadKeyCode::PageDown)),
+        57423 => Some(KeyCode::Keypad(KeypadKeyCode::Home)),
+        57424 => Some(KeyCode::Keypad(KeypadKeyCode::End)),
+        57425 => Some(KeyCode::Keypad(KeypadKeyCode::Insert)),
+        57426 => Some(KeyCode::Keypad(KeypadKeyCode::Delete)),
+        57427 => Some(KeyCode::Keypad(KeypadKeyCode::Begin)),
+        57428 => Some(KeyCode::Media(MediaKeyCode::Play)),
+        57429 => Some(KeyCode::Media(MediaKeyCode::Pause)),
+        57430 => Some(KeyCode::Media(MediaKeyCode::PlayPause)),
+        57431 => Some(KeyCode::Media(MediaKeyCode::Reverse)),
+        57432 => Some(KeyCode::Media(MediaKeyCode::Stop)),
+        57433 => Some(KeyCode::Media(MediaKeyCode::FastForward)),
+        57434 => Some(KeyCode::Media(MediaKeyCode::Rewind)),
+        57435 => Some(KeyCode::Media(MediaKeyCode::TrackNext)),
+        57436 => Some(KeyCode::Media(MediaKeyCode::TrackPrevious)),
+        57437 => Some(KeyCode::Media(MediaKeyCode::Record)),
+        57438 => Some(KeyCode::Media(MediaKeyCode::LowerVolume)),
+        57439 => Some(KeyCode::Media(MediaKeyCode::RaiseVolume)),
+        57440 => Some(KeyCode::Media(MediaKeyCode::MuteVolume)),
+        57441 => Some(KeyCode::Modifier(ModifierKeyCode::LeftShift)),
+        57442 => Some(KeyCode::Modifier(ModifierKeyCode::LeftControl)),
+        57443 => Some(KeyCode::Modifier(ModifierKeyCode::LeftAlt)),
+        57444 => Some(KeyCode::Modifier(ModifierKeyCode::LeftSuper)),
+        57445 => Some(KeyCode::Modifier(ModifierKeyCode::LeftHyper)),
+        57446 => Some(KeyCode::Modifier(ModifierKeyCode::LeftMeta)),
+        57447 => Some(KeyCode::Modifier(ModifierKeyCode::RightShift)),
+        57448 => Some(KeyCode::Modifier(ModifierKeyCode::RightControl)),
+        57449 => Some(KeyCode::Modifier(ModifierKeyCode::RightAlt)),
+        57450 => Some(KeyCode::Modifier(ModifierKeyCode::RightSuper)),
+        57451 => Some(KeyCode::Modifier(ModifierKeyCode::RightHyper)),
+        57452 => Some(KeyCode::Modifier(ModifierKeyCode::RightMeta)),
+        57453 => Some(KeyCode::Modifier(ModifierKeyCode::IsoLevel3Shift)),
+        57454 => Some(KeyCode::Modifier(ModifierKeyCode::IsoLevel5Shift)),
+        _ => None,
+    }
+}
+
 pub(crate) fn parse_csi_u_encoded_key_code(buffer: &[u8]) -> Result<Option<InternalEvent>> {
     assert!(buffer.starts_with(&[b'\x1B', b'['])); // ESC [
     assert!(buffer.ends_with(&[b'u']));
@@ -314,7 +405,9 @@ pub(crate) fn parse_csi_u_encoded_key_code(buffer: &[u8]) -> Result<Option<Inter
         };
 
     let keycode = {
-        if let Some(c) = char::from_u32(codepoint) {
+        if let Some(special_key_code) = translate_functional_key_code(codepoint) {
+            special_key_code
+        } else if let Some(c) = char::from_u32(codepoint) {
             match c {
                 '\x1B' => KeyCode::Esc,
                 '\r' => KeyCode::Enter,
@@ -925,6 +1018,41 @@ mod tests {
             parse_csi_u_encoded_key_code(b"\x1B[27u").unwrap(),
             Some(InternalEvent::Event(Event::Key(KeyEvent::new(
                 KeyCode::Esc,
+                KeyModifiers::empty()
+            )))),
+        );
+        assert_eq!(
+            parse_csi_u_encoded_key_code(b"\x1B[57358u").unwrap(),
+            Some(InternalEvent::Event(Event::Key(KeyEvent::new(
+                KeyCode::CapsLock,
+                KeyModifiers::empty()
+            )))),
+        );
+        assert_eq!(
+            parse_csi_u_encoded_key_code(b"\x1B[57376u").unwrap(),
+            Some(InternalEvent::Event(Event::Key(KeyEvent::new(
+                KeyCode::F(13),
+                KeyModifiers::empty()
+            )))),
+        );
+        assert_eq!(
+            parse_csi_u_encoded_key_code(b"\x1B[57399u").unwrap(),
+            Some(InternalEvent::Event(Event::Key(KeyEvent::new(
+                KeyCode::Keypad(KeypadKeyCode::Number(0)),
+                KeyModifiers::empty()
+            )))),
+        );
+        assert_eq!(
+            parse_csi_u_encoded_key_code(b"\x1B[57428u").unwrap(),
+            Some(InternalEvent::Event(Event::Key(KeyEvent::new(
+                KeyCode::Media(MediaKeyCode::Play),
+                KeyModifiers::empty()
+            )))),
+        );
+        assert_eq!(
+            parse_csi_u_encoded_key_code(b"\x1B[57441u").unwrap(),
+            Some(InternalEvent::Event(Event::Key(KeyEvent::new(
+                KeyCode::Modifier(ModifierKeyCode::LeftShift),
                 KeyModifiers::empty()
             )))),
         );


### PR DESCRIPTION
Followup to #688 .

Open question: is the nested structure for the new keycodes the best way? I didn't want to inflate the `KeyCode` enum, but the new structure results in somewhat verbose names.