### PR TITLE
Add bracketed paste parsing

### DIFF
--- a/.github/workflows/crossterm_test.yml
+++ b/.github/workflows/crossterm_test.yml
@@ -62,6 +62,9 @@ jobs:
     - name: Test all features
       run: cargo test --all-features -- --nocapture --test-threads 1
       continue-on-error: ${{ matrix.can-fail }}
+    - name: Test no default features
+      run: cargo test --no-default-features -- --nocapture --test-threads 1
+      continue-on-error: ${{ matrix.can-fail }}
     - name: Test Packaging
       if: matrix.rust == 'stable'
       run: cargo package

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,8 @@ all-features = true
 # Features
 #
 [features]
-default = []
+default = ["bracketed-paste"]
+bracketed-paste = []
 event-stream = ["futures-core"]
 
 #
@@ -72,6 +73,10 @@ serde_json = "1.0"
 #
 # Examples
 #
+[[example]]
+name = "event-read"
+required-features = ["bracketed-paste"]
+
 [[example]]
 name = "event-stream-async-std"
 required-features = ["event-stream"]

--- a/examples/event-match-modifiers.rs
+++ b/examples/event-match-modifiers.rs
@@ -2,7 +2,7 @@
 //!
 //! cargo run --example event-match-modifiers
 
-use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
 
 fn match_event(read_event: Event) {
     match read_event {

--- a/examples/event-read.rs
+++ b/examples/event-read.rs
@@ -8,8 +8,8 @@ use crossterm::event::poll;
 use crossterm::{
     cursor::position,
     event::{
-        read, DisableFocusChange, DisableMouseCapture, EnableFocusChange, EnableMouseCapture,
-        Event, KeyCode,
+        read, DisableBracketedPaste, DisableFocusChange, DisableMouseCapture, EnableBracketedPaste,
+        EnableFocusChange, EnableMouseCapture, Event, KeyCode,
     },
     execute,
     terminal::{disable_raw_mode, enable_raw_mode},
@@ -34,9 +34,9 @@ fn print_events() -> Result<()> {
             println!("Cursor position: {:?}\r", position());
         }
 
-        if let Event::Resize(_, _) = event {
-            let (original_size, new_size) = flush_resize_events(event);
-            println!("Resize from: {:?}, to: {:?}", original_size, new_size);
+        if let Event::Resize(x, y) = event {
+            let (original_size, new_size) = flush_resize_events((x, y));
+            println!("Resize from: {:?}, to: {:?}\r", original_size, new_size);
         }
 
         if event == Event::Key(KeyCode::Esc.into()) {
@@ -50,18 +50,15 @@ fn print_events() -> Result<()> {
 // Resize events can occur in batches.
 // With a simple loop they can be flushed.
 // This function will keep the first and last resize event.
-fn flush_resize_events(event: Event) -> ((u16, u16), (u16, u16)) {
-    if let Event::Resize(x, y) = event {
-        let mut last_resize = (x, y);
-        while let Ok(true) = poll(Duration::from_millis(50)) {
-            if let Ok(Event::Resize(x, y)) = read() {
-                last_resize = (x, y);
-            }
+fn flush_resize_events(first_resize: (u16, u16)) -> ((u16, u16), (u16, u16)) {
+    let mut last_resize = first_resize;
+    while let Ok(true) = poll(Duration::from_millis(50)) {
+        if let Ok(Event::Resize(x, y)) = read() {
+            last_resize = (x, y);
         }
-
-        return ((x, y), last_resize);
     }
-    ((0, 0), (0, 0))
+
+    return (first_resize, last_resize);
 }
 
 fn main() -> Result<()> {
@@ -70,13 +67,23 @@ fn main() -> Result<()> {
     enable_raw_mode()?;
 
     let mut stdout = stdout();
-    execute!(stdout, EnableFocusChange, EnableMouseCapture)?;
+    execute!(
+        stdout,
+        EnableBracketedPaste,
+        EnableFocusChange,
+        EnableMouseCapture
+    )?;
 
     if let Err(e) = print_events() {
         println!("Error: {:?}\r", e);
     }
 
-    execute!(stdout, DisableFocusChange, DisableMouseCapture)?;
+    execute!(
+        stdout,
+        DisableBracketedPaste,
+        DisableFocusChange,
+        DisableMouseCapture
+    )?;
 
     disable_raw_mode()
 }


### PR DESCRIPTION
This is another attempt at adding [bracketed paste parsing](https://github.com/crossterm-rs/crossterm/issues/545), like https://github.com/crossterm-rs/crossterm/pull/557. This version keeps from removing the `Copy` trait on `Event` and does all of the paste parsing in `parse_event`, so I'm hoping we can get it to an acceptable state.

Since pasting needs to read in a variable length string, I couldn't find a way to stuff the result in `Event` since it has `Copy`. Instead I've added an `input` module with its own read function. That read returns an `Input` enum that either contains `Event` or the pasted data. What I was thinking is that you'd use the `input` module if you wanted to parse terminal input that included variable length data, or you could keep using the `event` module if you only need the fixed length events. I didn't want to break all existing API clients and I wanted to let people pass around Events on the stack, and this was the best compromise I came up with.

I need to document this and give it a spin in Helix. I wanted to get some feedback on the approach before polishing it up though.