### PR TITLE
Add extra modifiers/state from kitty keyboard protocol

### DIFF
--- a/examples/event-read.rs
+++ b/examples/event-read.rs
@@ -4,7 +4,9 @@
 
 use std::io::stdout;
 
-use crossterm::event::poll;
+use crossterm::event::{
+    poll, KeyboardEnhancementFlags, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
+};
 use crossterm::{
     cursor::position,
     event::{
@@ -70,13 +72,27 @@ fn main() -> Result<()> {
     enable_raw_mode()?;
 
     let mut stdout = stdout();
-    execute!(stdout, EnableFocusChange, EnableMouseCapture)?;
+    execute!(
+        stdout,
+        EnableFocusChange,
+        EnableMouseCapture,
+        PushKeyboardEnhancementFlags(
+            KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
+                | KeyboardEnhancementFlags::REPORT_ALL_KEYS_AS_ESCAPE_CODES
+                | KeyboardEnhancementFlags::REPORT_EVENT_TYPES
+        )
+    )?;
 
     if let Err(e) = print_events() {
         println!("Error: {:?}\r", e);
     }
 
-    execute!(stdout, DisableFocusChange, DisableMouseCapture)?;
+    execute!(
+        stdout,
+        PopKeyboardEnhancementFlags,
+        DisableFocusChange,
+        DisableMouseCapture
+    )?;
 
     disable_raw_mode()
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -536,7 +536,7 @@ pub enum MouseButton {
 bitflags! {
     /// Represents key modifiers (shift, control, alt, etc.).
     ///
-    /// **Note:** `SUPER` can only be read if
+    /// **Note:** `SUPER`, `HYPER`, and `META` can only be read if
     /// [`KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES`] has been enabled with
     /// [`PushKeyboardEnhancementFlags`].
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -545,6 +545,8 @@ bitflags! {
         const CONTROL = 0b0000_0010;
         const ALT = 0b0000_0100;
         const SUPER = 0b0000_1000;
+        const HYPER = 0b0001_0000;
+        const META = 0b0010_0000;
         const NONE = 0b0000_0000;
     }
 }
@@ -568,16 +570,6 @@ bitflags! {
     pub struct KeyEventState: u8 {
         /// The key event origins from the keypad.
         const KEYPAD = 0b0000_0001;
-        /// The Hyper modifier was held for this key event.
-        ///
-        /// This modifier is uncommon; thus, it is not stored in `KeyEvent.state` to avoid
-        /// confusion or failures to match key events.
-        const MODIFIER_HYPER = 0b0000_0010;
-        /// The Meta modifier was held for this key event.
-        ///
-        /// This modifier is uncommon; thus, it is not stored in `KeyEvent.state` to avoid
-        /// confusion or failures to match key events.
-        const MODIFIER_META = 0b0000_0100;
         /// Caps Lock was enabled for this key event.
         ///
         /// **Note:** this is set for the initial press of Num Lock itself.

--- a/src/event.rs
+++ b/src/event.rs
@@ -534,12 +534,19 @@ pub enum MouseButton {
 }
 
 bitflags! {
-    /// Represents key modifiers (shift, control, alt).
+    /// Represents key modifiers (shift, control, alt, etc.).
+    ///
+    /// **Note:** `SUPER`, `HYPER`, and `META` can only be read if
+    /// [`KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES`] has been enabled with
+    /// [`PushKeyboardEnhancementFlags`].
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
     pub struct KeyModifiers: u8 {
         const SHIFT = 0b0000_0001;
         const CONTROL = 0b0000_0010;
         const ALT = 0b0000_0100;
+        const SUPER = 0b0000_1000;
+        const HYPER = 0b0001_0000;
+        const META = 0b0010_0000;
         const NONE = 0b0000_0000;
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -536,7 +536,7 @@ pub enum MouseButton {
 bitflags! {
     /// Represents key modifiers (shift, control, alt, etc.).
     ///
-    /// **Note:** `SUPER`, `HYPER`, and `META` can only be read if
+    /// **Note:** `SUPER` can only be read if
     /// [`KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES`] has been enabled with
     /// [`PushKeyboardEnhancementFlags`].
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -545,8 +545,6 @@ bitflags! {
         const CONTROL = 0b0000_0010;
         const ALT = 0b0000_0100;
         const SUPER = 0b0000_1000;
-        const HYPER = 0b0001_0000;
-        const META = 0b0010_0000;
         const NONE = 0b0000_0000;
     }
 }
@@ -562,10 +560,33 @@ pub enum KeyEventKind {
 
 bitflags! {
     /// Represents extra state about the key event.
+    ///
+    /// **Note:** This state can only be read if
+    /// [`KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES`] has been enabled with
+    /// [`PushKeyboardEnhancementFlags`].
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
     pub struct KeyEventState: u8 {
         /// The key event origins from the keypad.
         const KEYPAD = 0b0000_0001;
+        /// The Hyper modifier was held for this key event.
+        ///
+        /// This modifier is uncommon; thus, it is not stored in [`KeyEvent.state`] to avoid
+        /// confusion or failures to match key events.
+        const MODIFIER_HYPER = 0b0000_0010;
+        /// The Meta modifier was held for this key event.
+        ///
+        /// This modifier is uncommon; thus, it is not stored in [`KeyEvent.state`] to avoid
+        /// confusion or failures to match key events.
+        const MODIFIER_META = 0b0000_0100;
+        /// Caps Lock was enabled for this key event.
+        ///
+        /// **Note:** this is set for the initial press of Num Lock itself.
+        const CAPS_LOCK = 0b0000_1000;
+        /// Num Lock was enabled for this key event.
+        ///
+        /// **Note:** this is set for the initial press of Num Lock itself.
+        const NUM_LOCK = 0b0000_1000;
+        const NONE = 0b0000_0000;
     }
 }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -570,12 +570,12 @@ bitflags! {
         const KEYPAD = 0b0000_0001;
         /// The Hyper modifier was held for this key event.
         ///
-        /// This modifier is uncommon; thus, it is not stored in [`KeyEvent.state`] to avoid
+        /// This modifier is uncommon; thus, it is not stored in `KeyEvent.state` to avoid
         /// confusion or failures to match key events.
         const MODIFIER_HYPER = 0b0000_0010;
         /// The Meta modifier was held for this key event.
         ///
-        /// This modifier is uncommon; thus, it is not stored in [`KeyEvent.state`] to avoid
+        /// This modifier is uncommon; thus, it is not stored in `KeyEvent.state` to avoid
         /// confusion or failures to match key events.
         const MODIFIER_META = 0b0000_0100;
         /// Caps Lock was enabled for this key event.

--- a/src/event/sys/unix/parse.rs
+++ b/src/event/sys/unix/parse.rs
@@ -305,7 +305,7 @@ pub(crate) fn parse_csi_modifier_key_code(buffer: &[u8]) -> Result<Option<Intern
                 parse_modifiers(
                     (buffer[buffer.len() - 2] as char)
                         .to_digit(10)
-                        .ok_or(could_not_parse_event_error())? as u8,
+                        .ok_or_else(could_not_parse_event_error)? as u8,
                 ),
                 KeyEventKind::Press,
             )


### PR DESCRIPTION
Add support for:
* The Super/Command/Windows modifier.
* The Hyper/Meta modifers (stored in the `state` field as discussed in a previous PR).
* The Num Lock/Caps Lock state.

Please especially review the solution for Hyper/Meta.