### PR TITLE
Add OSC 52 clipboard setting command and a Windows equivalent

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ features = ["winuser", "winerror"]
 
 [target.'cfg(windows)'.dependencies]
 crossterm_winapi = "0.9"
+clipboard-win = { version = "4.4.2", features = ["std"] }
 
 #
 # UNIX dependencies
@@ -58,6 +59,7 @@ libc = "0.2"
 mio = { version = "0.8", features = ["os-poll"] }
 signal-hook = { version = "0.3.13" }
 signal-hook-mio = { version = "0.2.3", features = ["support-v0_8"] }
+base64 = "0.13.0"
 
 #
 # Dev dependencies (examples, ...)

--- a/examples/set-clipboard.rs
+++ b/examples/set-clipboard.rs
@@ -1,0 +1,54 @@
+//! Demonstrates how to set the clipboard.
+//!
+//! cargo run --example set-clipboard
+
+use std::io::stdout;
+
+use crossterm::{
+    event::{read, Event, KeyCode, KeyEvent},
+    execute,
+    terminal::{disable_raw_mode, enable_raw_mode, ClipboardKind, SetClipboard},
+    Result,
+};
+
+const HELP: &str = r#"Set clipboard
+ - The clipboard is set to typed characters
+ - Use Esc to quit
+"#;
+
+fn set_clipboard() -> Result<()> {
+    loop {
+        // Blocking read
+        let event = read()?;
+
+        println!("Event: {:?}\r", event);
+        if let Event::Key(KeyEvent {
+            code: KeyCode::Char(typed),
+            ..
+        }) = event
+        {
+            execute!(
+                stdout(),
+                SetClipboard::new(&typed.to_string(), ClipboardKind::Clipboard)
+            )?;
+            println!("Set clipboard to {}\r", typed);
+        }
+        if event == Event::Key(KeyCode::Esc.into()) {
+            break;
+        }
+    }
+
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    println!("{}", HELP);
+
+    enable_raw_mode()?;
+
+    if let Err(e) = set_clipboard() {
+        println!("Error: {:?}\r", e);
+    }
+
+    disable_raw_mode()
+}

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -436,7 +436,7 @@ impl Command for SetClipboard {
 
     #[cfg(windows)]
     fn execute_winapi(&self) -> Result<()> {
-        set_clipboard_string(&self.payload).map_err(|err| std::io::Error::from(err))
+        set_clipboard_string(&self.payload).map_err(std::io::Error::from)
     }
 
     #[cfg(windows)]


### PR DESCRIPTION
I'm using OSC 52 in https://github.com/helix-editor/helix/pull/3220. I'd like to pull it up into crossterm since it's a generally useful thing.