### PR TITLE
Derive strum `EnumIter` type for `Color`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ all-features = true
 default = ["bracketed-paste"]
 bracketed-paste = []
 event-stream = ["futures-core"]
+strum = ["dep:strum", "strum_macros"]
 
 #
 # Shared dependencies
@@ -40,6 +41,8 @@ parking_lot = "0.12"
 # optional deps only added when requested
 futures-core = { version = "0.3", optional = true, default-features = false }
 serde = { version = "1.0", features = ["derive"], optional = true }
+strum = { version = "0.24", optional = true }
+strum_macros = { version = "0.24", optional = true }
 
 #
 # Windows dependencies

--- a/src/style/types/color.rs
+++ b/src/style/types/color.rs
@@ -3,6 +3,9 @@ use std::{convert::AsRef, convert::TryFrom, result::Result, str::FromStr};
 #[cfg(feature = "serde")]
 use std::fmt;
 
+#[cfg(feature = "strum")]
+use strum_macros::EnumIter;
+
 use crate::style::parse_next_u8;
 
 /// Represents a color.
@@ -25,6 +28,7 @@ use crate::style::parse_next_u8;
 /// Most UNIX terminals and Windows 10 consoles support additional colors.
 /// See [`Color::Rgb`] or [`Color::AnsiValue`] for more info.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]
+#[cfg_attr(feature = "strum", derive(EnumIter))]
 pub enum Color {
     /// Resets the terminal color.
     Reset,


### PR DESCRIPTION
I found myself wanting to iterate over the variants of `Color`, thought this change might be useful upstream. Since most people will not need this I put it in a new optional feature.

I figure this might be controversial as adding an optional feature is potentially a big deal, so please let me know any feedback.

EDIT: if needed I can add the derive for other enums in the crate too to make proper use of the feature, as well as update [feature flags](https://github.com/crossterm-rs/crossterm#feature-flags) section of the readme. Didn't do it yet since I figured this could be an unlikely merge anyway 😅 