### PR TITLE
More readable table in source docs

### DIFF
--- a/src/style/types/color.rs
+++ b/src/style/types/color.rs
@@ -11,16 +11,16 @@ use crate::style::parse_next_u8;
 ///
 /// The following list of 16 base colors are available for almost all terminals (Windows 7 and 8 included).
 ///
-/// | Light | Dark |
-/// | :--| :--   |
-/// | `DarkGrey` | `Black` |
-/// | `Red` | `DarkRed` |
-/// | `Green` | `DarkGreen` |
-/// | `Yellow` | `DarkYellow` |
-/// | `Blue` | `DarkBlue` |
-/// | `Magenta` | `DarkMagenta` |
-/// | `Cyan` | `DarkCyan` |
-/// | `White` | `Grey` |
+/// | Light      | Dark          |
+/// | :--------- | :------------ |
+/// | `DarkGrey` | `Black`       |
+/// | `Red`      | `DarkRed`     |
+/// | `Green`    | `DarkGreen`   |
+/// | `Yellow`   | `DarkYellow`  |
+/// | `Blue`     | `DarkBlue`    |
+/// | `Magenta`  | `DarkMagenta` |
+/// | `Cyan`     | `DarkCyan`    |
+/// | `White`    | `Grey`        |
 ///
 /// Most UNIX terminals and Windows 10 consoles support additional colors.
 /// See [`Color::Rgb`] or [`Color::AnsiValue`] for more info.


### PR DESCRIPTION
Minor change, doesn't affect docs generated by cargo, but for those reading docs in the source this just makes it a bit prettier and more readable.