### PR TITLE
Fix typo on KeyEventState::CAPS_LOCK docs

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -623,7 +623,7 @@ bitflags! {
         const KEYPAD = 0b0000_0001;
         /// Caps Lock was enabled for this key event.
         ///
-        /// **Note:** this is set for the initial press of Num Lock itself.
+        /// **Note:** this is set for the initial press of Caps Lock itself.
         const CAPS_LOCK = 0b0000_1000;
         /// Num Lock was enabled for this key event.
         ///


### PR DESCRIPTION
When looking through the docs for the 0.25.0 upgrade, I noticed what, I believe, was a typo or bad copy-paste between the docs for `KeyEventState::NUM_LOCK` and `KeyEventState::CAPS_LOCK`.