### PR TITLE
Use `select()` instead of `mio` polling in Unix EventSource

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,9 +56,7 @@ crossterm_winapi = "0.9"
 #
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
-mio = { version = "0.8", features = ["os-poll"] }
 signal-hook = { version = "0.3.13" }
-signal-hook-mio = { version = "0.2.3", features = ["support-v0_8"] }
 
 #
 # Dev dependencies (examples, ...)

--- a/src/event/source.rs
+++ b/src/event/source.rs
@@ -5,6 +5,8 @@ use super::sys::Waker;
 use super::InternalEvent;
 
 #[cfg(unix)]
+pub(crate) mod select;
+#[cfg(unix)]
 pub(crate) mod unix;
 #[cfg(windows)]
 pub(crate) mod windows;

--- a/src/event/source/select.rs
+++ b/src/event/source/select.rs
@@ -1,0 +1,183 @@
+use std::{fmt::Debug, mem::MaybeUninit, time::Duration};
+
+use crate::Result;
+
+#[repr(transparent)]
+#[derive(Clone)]
+pub struct FdSet(libc::fd_set);
+
+impl Default for FdSet {
+    fn default() -> Self {
+        let mut fd_set = MaybeUninit::<libc::fd_set>::uninit();
+        FdSet(unsafe {
+            libc::FD_ZERO(fd_set.as_mut_ptr());
+            fd_set.assume_init()
+        })
+    }
+}
+
+impl Debug for FdSet {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut set = f.debug_set();
+        for i in 0..libc::FD_SETSIZE {
+            if self.is_set(i as i32) {
+                set.entry(&i);
+            }
+        }
+        set.finish()
+    }
+}
+
+impl FdSet {
+    #[inline]
+    pub fn set(&mut self, fd: i32) {
+        unsafe { libc::FD_SET(fd, self.as_mut_ptr()) }
+    }
+
+    #[inline]
+    pub fn clear(&mut self, fd: i32) {
+        unsafe { libc::FD_CLR(fd, self.as_mut_ptr()) }
+    }
+
+    #[inline]
+    pub fn as_mut_ptr(&mut self) -> *mut libc::fd_set {
+        &mut self.0 as *mut _
+    }
+
+    #[inline]
+    pub fn as_ptr(&self) -> *const libc::fd_set {
+        &self.0 as *const _
+    }
+    #[inline]
+    pub fn is_set(&self, fd: i32) -> bool {
+        unsafe { libc::FD_ISSET(fd, self.as_ptr()) }
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct FdSelector {
+    pub fd: i32,
+    pub read: bool,
+    pub write: bool,
+    pub error: bool,
+}
+
+impl FdSelector {
+    pub fn new(fd: i32, read: bool, write: bool, error: bool) -> Self {
+        FdSelector {
+            fd,
+            read,
+            write,
+            error,
+        }
+    }
+
+    pub fn read(fd: i32) -> Self {
+        FdSelector {
+            fd,
+            read: true,
+            write: false,
+            error: false,
+        }
+    }
+
+    pub fn write(fd: i32) -> Self {
+        FdSelector {
+            fd,
+            read: false,
+            write: true,
+            error: false,
+        }
+    }
+
+    pub fn error(fd: i32) -> Self {
+        FdSelector {
+            fd,
+            read: false,
+            write: false,
+            error: true,
+        }
+    }
+}
+
+#[derive(Clone, Default, Debug)]
+pub(crate) struct Selector {
+    read: FdSet,
+    write: FdSet,
+    error: FdSet,
+    max_fd: i32,
+}
+
+impl Selector {
+    pub fn select(&mut self, timeout: Option<Duration>) -> Result<usize> {
+        let Selector {
+            read, write, error, ..
+        } = self;
+        let read = read as *mut _ as *mut libc::fd_set;
+        let write = write as *mut _ as *mut libc::fd_set;
+        let error = error as *mut _ as *mut libc::fd_set;
+        let mut timeval = timeout.map(|t| libc::timeval {
+            tv_sec: t.as_secs() as libc::time_t,
+            tv_usec: t.subsec_micros() as libc::suseconds_t,
+        });
+        let timeval_ptr = timeval
+            .as_mut()
+            .map(|timeval| timeval as *mut _)
+            .unwrap_or(std::ptr::null_mut());
+        let result = unsafe { libc::select(self.max_fd + 1, read, write, error, timeval_ptr) };
+
+        if result >= 0 {
+            Ok(result as usize)
+        } else {
+            Err(std::io::Error::last_os_error())
+        }
+    }
+
+    #[inline]
+    pub fn set(&mut self, selector: FdSelector) -> &mut Self {
+        if selector.read {
+            self.read.set(selector.fd)
+        }
+        if selector.write {
+            self.write.set(selector.fd)
+        }
+        if selector.error {
+            self.error.set(selector.fd)
+        }
+        self.max_fd = self.max_fd.max(selector.fd);
+        self
+    }
+    #[inline]
+    pub fn clear(&mut self, selector: FdSelector) -> &mut Self {
+        if selector.read {
+            self.read.clear(selector.fd)
+        }
+        if selector.write {
+            self.write.clear(selector.fd)
+        }
+        if selector.error {
+            self.error.clear(selector.fd)
+        }
+        self
+    }
+
+    pub fn get(&self, fd: i32) -> Option<FdSelector> {
+        let read = self.read.is_set(fd);
+        let write = self.write.is_set(fd);
+        let error = self.error.is_set(fd);
+        if read | write | error {
+            Some(FdSelector {
+                fd,
+                read,
+                write,
+                error,
+            })
+        } else {
+            None
+        }
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = FdSelector> + '_ {
+        (0..=self.max_fd).filter_map(|i| self.get(i))
+    }
+}

--- a/src/event/source/unix.rs
+++ b/src/event/source/unix.rs
@@ -1,27 +1,26 @@
-use std::{collections::VecDeque, io, time::Duration};
+use std::io::Read;
+use std::os::unix::prelude::AsRawFd;
+use std::{collections::VecDeque, io, os::unix::net::UnixStream, time::Duration};
 
-use mio::{unix::SourceFd, Events, Interest, Poll, Token};
-use signal_hook_mio::v0_8::Signals;
+use signal_hook::consts::SIGWINCH;
+use signal_hook::low_level::pipe;
 
+use crate::event::Event;
 use crate::Result;
 
 #[cfg(feature = "event-stream")]
 use super::super::sys::Waker;
-use super::super::{
-    source::EventSource,
-    sys::unix::{
-        file_descriptor::{tty_fd, FileDesc},
-        parse::parse_event,
+use super::{
+    super::{
+        sys::unix::{
+            file_descriptor::{tty_fd, FileDesc},
+            parse::parse_event,
+        },
+        InternalEvent,
     },
-    timeout::PollTimeout,
-    Event, InternalEvent,
+    select::{FdSelector, Selector},
+    EventSource,
 };
-
-// Tokens to identify file descriptor
-const TTY_TOKEN: Token = Token(0);
-const SIGNAL_TOKEN: Token = Token(1);
-#[cfg(feature = "event-stream")]
-const WAKE_TOKEN: Token = Token(2);
 
 // I (@zrzka) wasn't able to read more than 1_022 bytes when testing
 // reading on macOS/Linux -> we don't need bigger buffer and 1k of bytes
@@ -29,14 +28,11 @@ const WAKE_TOKEN: Token = Token(2);
 const TTY_BUFFER_SIZE: usize = 1_024;
 
 pub(crate) struct UnixInternalEventSource {
-    poll: Poll,
-    events: Events,
     parser: Parser,
     tty_buffer: [u8; TTY_BUFFER_SIZE],
     tty_fd: FileDesc,
-    signals: Signals,
-    #[cfg(feature = "event-stream")]
-    waker: Waker,
+    selector: Selector,
+    resize_signal: UnixStream,
 }
 
 impl UnixInternalEventSource {
@@ -45,128 +41,83 @@ impl UnixInternalEventSource {
     }
 
     pub(crate) fn from_file_descriptor(input_fd: FileDesc) -> Result<Self> {
-        let poll = Poll::new()?;
-        let registry = poll.registry();
-
-        let tty_raw_fd = input_fd.raw_fd();
-        let mut tty_ev = SourceFd(&tty_raw_fd);
-        registry.register(&mut tty_ev, TTY_TOKEN, Interest::READABLE)?;
-
-        let mut signals = Signals::new(&[signal_hook::consts::SIGWINCH])?;
-        registry.register(&mut signals, SIGNAL_TOKEN, Interest::READABLE)?;
-
-        #[cfg(feature = "event-stream")]
-        let waker = Waker::new(registry, WAKE_TOKEN)?;
+        let (mut read, write) = UnixStream::pair()?;
+        pipe::register(SIGWINCH, write)?;
 
         Ok(UnixInternalEventSource {
-            poll,
-            events: Events::with_capacity(3),
+            resize_signal: read,
             parser: Parser::default(),
             tty_buffer: [0u8; TTY_BUFFER_SIZE],
             tty_fd: input_fd,
-            signals,
-            #[cfg(feature = "event-stream")]
-            waker,
+            selector: Selector::default(),
         })
     }
 }
 
 impl EventSource for UnixInternalEventSource {
     fn try_read(&mut self, timeout: Option<Duration>) -> Result<Option<InternalEvent>> {
-        if let Some(event) = self.parser.next() {
-            return Ok(Some(event));
+        let tty_fd = self.tty_fd.raw_fd();
+        let resize_fd = self.resize_signal.as_raw_fd();
+        self.selector.set(FdSelector::read(tty_fd));
+        self.selector.set(FdSelector::read(resize_fd));
+
+        // todo signals and such
+        let result = self.selector.select(timeout)?;
+        if result == 0 {
+            return Ok(None);
         }
-
-        let timeout = PollTimeout::new(timeout);
-
-        loop {
-            if let Err(e) = self.poll.poll(&mut self.events, timeout.leftover()) {
-                // Mio will throw an interrupted error in case of cursor position retrieval. We need to retry until it succeeds.
-                // Previous versions of Mio (< 0.7) would automatically retry the poll call if it was interrupted (if EINTR was returned).
-                // https://docs.rs/mio/0.7.0/mio/struct.Poll.html#notes
-                if e.kind() == io::ErrorKind::Interrupted {
-                    continue;
-                } else {
-                    return Err(e);
-                }
-            };
-
-            if self.events.is_empty() {
-                // No readiness events = timeout
-                return Ok(None);
-            }
-
-            for token in self.events.iter().map(|x| x.token()) {
-                match token {
-                    TTY_TOKEN => {
-                        loop {
-                            match self.tty_fd.read(&mut self.tty_buffer, TTY_BUFFER_SIZE) {
-                                Ok(read_count) => {
-                                    if read_count > 0 {
-                                        self.parser.advance(
-                                            &self.tty_buffer[..read_count],
-                                            read_count == TTY_BUFFER_SIZE,
-                                        );
-                                    }
-                                }
-                                Err(e) => {
-                                    // No more data to read at the moment. We will receive another event
-                                    if e.kind() == io::ErrorKind::WouldBlock {
-                                        break;
-                                    }
-                                    // once more data is available to read.
-                                    else if e.kind() == io::ErrorKind::Interrupted {
-                                        continue;
-                                    }
-                                }
-                            };
-
-                            if let Some(event) = self.parser.next() {
-                                return Ok(Some(event));
+        for FdSelector { fd, .. } in self.selector.iter() {
+            if fd == tty_fd {
+                loop {
+                    match self.tty_fd.read(&mut self.tty_buffer, TTY_BUFFER_SIZE) {
+                        Ok(read_count) => {
+                            if read_count > 0 {
+                                self.parser.advance(
+                                    &self.tty_buffer[..read_count],
+                                    read_count == TTY_BUFFER_SIZE,
+                                );
                             }
                         }
-                    }
-                    SIGNAL_TOKEN => {
-                        for signal in self.signals.pending() {
-                            match signal {
-                                signal_hook::consts::SIGWINCH => {
-                                    // TODO Should we remove tput?
-                                    //
-                                    // This can take a really long time, because terminal::size can
-                                    // launch new process (tput) and then it parses its output. It's
-                                    // not a really long time from the absolute time point of view, but
-                                    // it's a really long time from the mio, async-std/tokio executor, ...
-                                    // point of view.
-                                    let new_size = crate::terminal::size()?;
-                                    return Ok(Some(InternalEvent::Event(Event::Resize(
-                                        new_size.0, new_size.1,
-                                    ))));
-                                }
-                                _ => unreachable!("Synchronize signal registration & handling"),
-                            };
+                        Err(e) => {
+                            // No more data to read at the moment. We will receive another event
+                            if e.kind() == io::ErrorKind::WouldBlock {
+                                break;
+                            }
+                            // once more data is available to read.
+                            else if e.kind() == io::ErrorKind::Interrupted {
+                                continue;
+                            }
                         }
+                    };
+
+                    if let Some(event) = self.parser.next() {
+                        return Ok(Some(event));
                     }
-                    #[cfg(feature = "event-stream")]
-                    WAKE_TOKEN => {
-                        return Err(std::io::Error::new(
-                            std::io::ErrorKind::Interrupted,
-                            "Poll operation was woken up by `Waker::wake`",
-                        ));
-                    }
-                    _ => unreachable!("Synchronize Evented handle registration & token handling"),
+                }
+            } else if fd == resize_fd {
+                let mut buff = [0];
+                if self.resize_signal.read(&mut buff)? > 0 {
+                    // TODO Should we remove tput?
+                    //
+                    // This can take a really long time, because terminal::size can
+                    // launch new process (tput) and then it parses its output. It's
+                    // not a really long time from the absolute time point of view, but
+                    // it's a really long time from the mio, async-std/tokio executor, ...
+                    // point of view.
+                    let new_size = crate::terminal::size()?;
+                    return Ok(Some(InternalEvent::Event(Event::Resize(
+                        new_size.0, new_size.1,
+                    ))));
                 }
             }
-
-            // Processing above can take some time, check if timeout expired
-            if timeout.elapsed() {
-                return Ok(None);
-            }
+            // TODO other fds
         }
+        Ok(None)
     }
 
     #[cfg(feature = "event-stream")]
     fn waker(&self) -> Waker {
-        self.waker.clone()
+        todo!()
     }
 }
 

--- a/src/event/sys/unix/file_descriptor.rs
+++ b/src/event/sys/unix/file_descriptor.rs
@@ -1,6 +1,9 @@
 use std::{
     fs, io,
-    os::unix::io::{IntoRawFd, RawFd},
+    os::unix::{
+        io::{IntoRawFd, RawFd},
+        prelude::AsRawFd,
+    },
 };
 
 use libc::size_t;
@@ -60,6 +63,12 @@ impl Drop for FileDesc {
             // opened after we closed ours.
             let _ = unsafe { libc::close(self.fd) };
         }
+    }
+}
+
+impl AsRawFd for FileDesc {
+    fn as_raw_fd(&self) -> RawFd {
+        self.raw_fd()
     }
 }
 

--- a/src/event/sys/unix/waker.rs
+++ b/src/event/sys/unix/waker.rs
@@ -1,6 +1,8 @@
-use std::sync::{Arc, Mutex};
-
-use mio::{Registry, Token};
+use std::{
+    io::Write,
+    os::unix::net::UnixStream,
+    sync::{Arc, Mutex},
+};
 
 use crate::Result;
 
@@ -8,22 +10,23 @@ use crate::Result;
 /// This type wraps `mio::Waker`, for more information see its documentation.
 #[derive(Clone, Debug)]
 pub(crate) struct Waker {
-    inner: Arc<Mutex<mio::Waker>>,
+    inner: Arc<Mutex<UnixStream>>,
 }
 
 impl Waker {
     /// Create a new `Waker`.
-    pub(crate) fn new(registry: &Registry, waker_token: Token) -> Result<Self> {
-        Ok(Self {
-            inner: Arc::new(Mutex::new(mio::Waker::new(registry, waker_token)?)),
-        })
+    pub(crate) fn new(writer: UnixStream) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(writer)),
+        }
     }
 
     /// Wake up the [`Poll`] associated with this `Waker`.
     ///
     /// Readiness is set to `Ready::readable()`.
     pub(crate) fn wake(&self) -> Result<()> {
-        self.inner.lock().unwrap().wake()
+        self.inner.lock().unwrap().write(&[0])?;
+        Ok(())
     }
 
     /// Resets the state so the same waker can be reused.

--- a/src/event/sys/unix/waker.rs
+++ b/src/event/sys/unix/waker.rs
@@ -6,8 +6,7 @@ use std::{
 
 use crate::Result;
 
-/// Allows to wake up the `mio::Poll::poll()` method.
-/// This type wraps `mio::Waker`, for more information see its documentation.
+/// Allows to wake up the EventSource::try_read() method.
 #[derive(Clone, Debug)]
 pub(crate) struct Waker {
     inner: Arc<Mutex<UnixStream>>,


### PR DESCRIPTION
I've run into #500 (which is caused by https://github.com/tokio-rs/mio/issues/1377) several times now, so here is a shot at reimplementing `EventSource` using `select()` instead of `mio` as discussed in the issue. feedback is appreciated, I tested it a bit and it seems to work fine, but the code could use some cleanup.

I thought about using [`nix`](https://docs.rs/nix/latest/nix/sys/select/fn.select.html) but decided against adding another dependency since using `libc::select()` is pretty straightforward.

Fixes #500, unblocks #407 
