### PR TITLE
Make Windows resize event match `terminal::size`

### DIFF
--- a/src/event/source/windows.rs
+++ b/src/event/source/windows.rs
@@ -64,7 +64,8 @@ impl EventSource for WindowsEventSource {
                             mouse_event
                         }
                         InputRecord::WindowBufferSizeEvent(record) => {
-                            Some(Event::Resize(record.size.x as u16, record.size.y as u16))
+                            // windows starts counting at 0, unix at 1, add one to replicate unix behaviour.
+                            Some(Event::Resize(record.size.x as u16 + 1, record.size.y as u16 + 1))
                         }
                         InputRecord::FocusEvent(record) => {
                             let event = if record.set_focus {

--- a/src/event/source/windows.rs
+++ b/src/event/source/windows.rs
@@ -65,7 +65,10 @@ impl EventSource for WindowsEventSource {
                         }
                         InputRecord::WindowBufferSizeEvent(record) => {
                             // windows starts counting at 0, unix at 1, add one to replicate unix behaviour.
-                            Some(Event::Resize(record.size.x as u16 + 1, record.size.y as u16 + 1))
+                            Some(Event::Resize(
+                                record.size.x as u16 + 1,
+                                record.size.y as u16 + 1,
+                            ))
                         }
                         InputRecord::FocusEvent(record) => {
                             let event = if record.set_focus {


### PR DESCRIPTION
Previously, results from a Resize event were 1 less than results from `terminal::size` in both x and y dimensions.

This PR fixes #713