### PR TITLE
Add Chrome OS Crostini to tested terminals list

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ WARNING: Do not change following heading title as it's used in the URL by other 
 - (Arch) Kitty
 - Linux Mint
 - (OpenSuse) Alacritty
+- (Chrome OS) Crostini
 
 This crate supports all UNIX terminals and Windows terminals down to Windows 7; however, not all of the
 terminals have been tested. If you have used this library for a terminal other than the above list without


### PR DESCRIPTION
I have never had any issues with Crossterm on Crostini and I didn't even know it wasn't tested. Well, here you go.