### PR TITLE
Add a function for checking keyboard enhancement support

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -932,6 +932,12 @@ pub(crate) enum InternalEvent {
     /// A cursor position (`col`, `row`).
     #[cfg(unix)]
     CursorPosition(u16, u16),
+    /// The progressive keyboard enhancement flags enabled by the terminal.
+    #[cfg(unix)]
+    KeyboardEnhancementFlags(KeyboardEnhancementFlags),
+    /// Attributes and architectural class of the terminal.
+    #[cfg(unix)]
+    PrimaryDeviceAttributes,
 }
 
 #[cfg(test)]

--- a/src/event/filter.rs
+++ b/src/event/filter.rs
@@ -17,6 +17,35 @@ impl Filter for CursorPositionFilter {
     }
 }
 
+#[cfg(unix)]
+#[derive(Debug, Clone)]
+pub(crate) struct KeyboardEnhancementFlagsFilter;
+
+#[cfg(unix)]
+impl Filter for KeyboardEnhancementFlagsFilter {
+    fn eval(&self, event: &InternalEvent) -> bool {
+        // This filter checks for either a KeyboardEnhancementFlags response or
+        // a PrimaryDeviceAttributes response. If we receive the PrimaryDeviceAttributes
+        // response but not KeyboardEnhancementFlags, the terminal does not support
+        // progressive keyboard enhancement.
+        matches!(
+            *event,
+            InternalEvent::KeyboardEnhancementFlags(_) | InternalEvent::PrimaryDeviceAttributes
+        )
+    }
+}
+
+#[cfg(unix)]
+#[derive(Debug, Clone)]
+pub(crate) struct PrimaryDeviceAttributesFilter;
+
+#[cfg(unix)]
+impl Filter for PrimaryDeviceAttributesFilter {
+    fn eval(&self, event: &InternalEvent) -> bool {
+        matches!(*event, InternalEvent::PrimaryDeviceAttributes)
+    }
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct EventFilter;
 
@@ -45,13 +74,31 @@ impl Filter for InternalEventFilter {
 #[cfg(unix)]
 mod tests {
     use super::{
-        super::Event, CursorPositionFilter, EventFilter, Filter, InternalEvent, InternalEventFilter,
+        super::Event, CursorPositionFilter, EventFilter, Filter, InternalEvent,
+        InternalEventFilter, KeyboardEnhancementFlagsFilter, PrimaryDeviceAttributesFilter,
     };
 
     #[test]
     fn test_cursor_position_filter_filters_cursor_position() {
         assert!(!CursorPositionFilter.eval(&InternalEvent::Event(Event::Resize(10, 10))));
         assert!(CursorPositionFilter.eval(&InternalEvent::CursorPosition(0, 0)));
+    }
+
+    #[test]
+    fn test_keyboard_enhancement_status_filter_filters_keyboard_enhancement_status() {
+        assert!(!KeyboardEnhancementFlagsFilter.eval(&InternalEvent::Event(Event::Resize(10, 10))));
+        assert!(
+            KeyboardEnhancementFlagsFilter.eval(&InternalEvent::KeyboardEnhancementFlags(
+                crate::event::KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
+            ))
+        );
+        assert!(KeyboardEnhancementFlagsFilter.eval(&InternalEvent::PrimaryDeviceAttributes));
+    }
+
+    #[test]
+    fn test_primary_device_attributes_filter_filters_primary_device_attributes() {
+        assert!(!PrimaryDeviceAttributesFilter.eval(&InternalEvent::Event(Event::Resize(10, 10))));
+        assert!(PrimaryDeviceAttributesFilter.eval(&InternalEvent::PrimaryDeviceAttributes));
     }
 
     #[test]

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -98,6 +98,8 @@ use crate::{csi, impl_display, Result};
 
 pub(crate) mod sys;
 
+pub use sys::supports_keyboard_enhancement;
+
 /// Tells whether the raw mode is enabled.
 ///
 /// Please have a look at the [raw mode](./index.html#raw-mode) section.

--- a/src/terminal/sys.rs
+++ b/src/terminal/sys.rs
@@ -1,7 +1,11 @@
 //! This module provides platform related functions.
 
 #[cfg(unix)]
+pub use self::unix::supports_keyboard_enhancement;
+#[cfg(unix)]
 pub(crate) use self::unix::{disable_raw_mode, enable_raw_mode, is_raw_mode_enabled, size};
+#[cfg(windows)]
+pub use self::windows::supports_keyboard_enhancement;
 #[cfg(windows)]
 pub(crate) use self::windows::{
     clear, disable_raw_mode, enable_raw_mode, is_raw_mode_enabled, scroll_down, scroll_up,

--- a/src/terminal/sys/unix.rs
+++ b/src/terminal/sys/unix.rs
@@ -1,7 +1,9 @@
 //! UNIX related logic for terminal manipulation.
 
 use std::fs::File;
+use std::io::Write;
 use std::os::unix::io::{IntoRawFd, RawFd};
+use std::time::Duration;
 use std::{io, mem, process};
 
 use libc::{
@@ -11,7 +13,9 @@ use libc::{
 use parking_lot::Mutex;
 
 use crate::error::Result;
+use crate::event::filter::{KeyboardEnhancementFlagsFilter, PrimaryDeviceAttributesFilter};
 use crate::event::sys::unix::file_descriptor::{tty_fd, FileDesc};
+use crate::event::{poll_internal, read_internal, InternalEvent};
 
 // Some(Termios) -> we're in the raw mode and this is the previous mode
 // None -> we're not in the raw mode
@@ -86,6 +90,72 @@ pub(crate) fn disable_raw_mode() -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Queries the terminal's support for progressive keyboard enhancement.
+///
+/// On unix systems, this function will block and possibly time out while
+/// [`crossterm::event::read`](crate::event::read) or [`crossterm::event::poll`](crate::event::poll) are being called.
+pub fn supports_keyboard_enhancement() -> Result<bool> {
+    if is_raw_mode_enabled() {
+        read_supports_keyboard_enhancement_raw()
+    } else {
+        read_supports_keyboard_enhancement_flags()
+    }
+}
+
+fn read_supports_keyboard_enhancement_flags() -> Result<bool> {
+    enable_raw_mode()?;
+    let flags = read_supports_keyboard_enhancement_raw();
+    disable_raw_mode()?;
+    flags
+}
+
+fn read_supports_keyboard_enhancement_raw() -> Result<bool> {
+    // This is the recommended method for testing support for the keyboard enhancement protocol.
+    // We send a query for the flags supported by the terminal and then the primary device attributes
+    // query. If we receive the primary device attributes response but not the keyboard enhancement
+    // flags, none of the flags are supported.
+    //
+    // See <https://sw.kovidgoyal.net/kitty/keyboard-protocol/#detection-of-support-for-this-protocol>
+
+    // ESC [ ? u        Query progressive keyboard enhancement flags (kitty protocol).
+    // ESC [ c          Query primary device attributes.
+    const QUERY: &[u8] = b"\x1B[?u\x1B[c";
+
+    if let Err(_) = File::open("/dev/tty").and_then(|mut file| {
+        file.write_all(QUERY)?;
+        file.flush()
+    }) {
+        let mut stdout = io::stdout();
+        stdout.write_all(QUERY)?;
+        stdout.flush()?;
+    }
+
+    loop {
+        match poll_internal(
+            Some(Duration::from_millis(2000)),
+            &KeyboardEnhancementFlagsFilter,
+        ) {
+            Ok(true) => {
+                match read_internal(&KeyboardEnhancementFlagsFilter) {
+                    Ok(InternalEvent::KeyboardEnhancementFlags(_current_flags)) => {
+                        // Flush the PrimaryDeviceAttributes out of the event queue.
+                        read_internal(&PrimaryDeviceAttributesFilter).ok();
+                        return Ok(true);
+                    }
+                    _ => return Ok(false),
+                }
+            }
+            Ok(false) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    "The keyboard enhancement status could not be read within a normal duration",
+                ));
+            }
+            Err(_) => {}
+        }
+    }
 }
 
 /// execute tput with the given argument and parse

--- a/src/terminal/sys/windows.rs
+++ b/src/terminal/sys/windows.rs
@@ -58,6 +58,13 @@ pub(crate) fn size() -> Result<(u16, u16)> {
     ))
 }
 
+/// Queries the terminal's support for progressive keyboard enhancement.
+///
+/// This always returns `Ok(false)` on Windows.
+pub fn supports_keyboard_enhancement() -> Result<bool> {
+    Ok(false)
+}
+
 pub(crate) fn clear(clear_type: ClearType) -> Result<()> {
     let screen_buffer = ScreenBuffer::current()?;
     let csbi = screen_buffer.info()?;


### PR DESCRIPTION
This follows the Kitty documentation's recommended way to check for progressive keyboard enhancement: query the flags and then query the primary device attributes (which is broadly supported). If we receive the response to the flags query, we return the flags. Otherwise, the terminal must not support progressive keyboard enhancement.

Closes #717