### PR TITLE
Improved F1 through F4 handling

### DIFF
--- a/src/event/sys/unix/parse.rs
+++ b/src/event/sys/unix/parse.rs
@@ -203,7 +203,8 @@ pub(crate) fn parse_csi(buffer: &[u8]) -> Result<Option<InternalEvent>> {
                         // Position response. If it contains an event
                         // type, it's definitely not a cursor
                         // position.
-                        b'R' if buffer[buffer.len() - 3] != b':' => return parse_csi_cursor_position(buffer),
+                        b'R' if buffer[buffer.len() - 3] != b':' =>
+                            return parse_csi_cursor_position(buffer),
                         _ => return parse_csi_modifier_key_code(buffer),
                     }
                 }

--- a/src/event/sys/unix/parse.rs
+++ b/src/event/sys/unix/parse.rs
@@ -170,13 +170,12 @@ pub(crate) fn parse_csi(buffer: &[u8]) -> Result<Option<InternalEvent>> {
         b'I' => Some(Event::FocusGained),
         b'O' => Some(Event::FocusLost),
         b';' => return parse_csi_modifier_key_code(buffer),
-        // P, Q, R, and S for compatibility with Kitty keyboard protocol,
+        // P, Q, and S for compatibility with Kitty keyboard protocol,
         // as the 1 in 'CSI 1 P' etc. must be omitted if there are no
         // modifiers pressed:
         // https://sw.kovidgoyal.net/kitty/keyboard-protocol/#legacy-functional-keys
         b'P' => Some(Event::Key(KeyCode::F(1).into())),
         b'Q' => Some(Event::Key(KeyCode::F(2).into())),
-        b'R' => Some(Event::Key(KeyCode::F(3).into())),
         b'S' => Some(Event::Key(KeyCode::F(4).into())),
         b'0'..=b'9' => {
             // Numbered escape code.

--- a/src/event/sys/unix/parse.rs
+++ b/src/event/sys/unix/parse.rs
@@ -31,6 +31,14 @@ pub(crate) fn parse_event(buffer: &[u8], input_available: bool) -> Result<Option
         return Ok(None);
     }
 
+    println!(
+        "{:?}",
+        buffer
+            .iter()
+            .map(|v| char::from_u32(*v as u32).unwrap())
+            .collect::<String>()
+    );
+
     match buffer[0] {
         b'\x1B' => {
             if buffer.len() == 1 {
@@ -197,15 +205,6 @@ pub(crate) fn parse_csi(buffer: &[u8]) -> Result<Option<InternalEvent>> {
                         b'M' => return parse_csi_rxvt_mouse(buffer),
                         b'~' => return parse_csi_special_key_code(buffer),
                         b'u' => return parse_csi_u_encoded_key_code(buffer),
-                        // In the case of an R in the last byte, we
-                        // need to check whether it's a Kitty keyboard
-                        // protocol F3 event or a Report Cursor
-                        // Position response. The protocol
-                        // specification states that when used as a
-                        // key event, the bytes following the CSI must
-                        // be '1;' so we check that.
-                        b'R' if buffer.starts_with(b"\x1B[1;") =>
-                            return parse_csi_modifier_key_code(buffer),
                         b'R' => return parse_csi_cursor_position(buffer),
                         _ => return parse_csi_modifier_key_code(buffer),
                     }

--- a/src/event/sys/unix/parse.rs
+++ b/src/event/sys/unix/parse.rs
@@ -31,14 +31,6 @@ pub(crate) fn parse_event(buffer: &[u8], input_available: bool) -> Result<Option
         return Ok(None);
     }
 
-    println!(
-        "{:?}",
-        buffer
-            .iter()
-            .map(|v| char::from_u32(*v as u32).unwrap())
-            .collect::<String>()
-    );
-
     match buffer[0] {
         b'\x1B' => {
             if buffer.len() == 1 {


### PR DESCRIPTION
There are some quirks to the handling of F1 through F4 in the Kitty keyboard protocol that crossterm was not handling, causing presses without modifiers of F1, F2, and F4 to be discarded without triggering an event. F3 shared in that problem, but had the additional problem that modified key presses, repeats, and releases were all discarded without triggering an event.

The problems with F1, F2, F4, and unmodified F3 were easily solved, just by making crossterm recognize the escape codes used to encode their unmodified key presses. The change is trivial and highly compatible.

The problems with F3 are more complex. For reasons unclear to me, the escape code sent for a modified F3 press or any F3 repeat or release is structurally identical to the escape code sent in response to a "Report Cursor Position" query, and must be disambiguated. The Kitty keyboard protocol documentation specifies that the key event version of the escape code will have the CSI followed by exactly "1;", so that byte sequence is used as a flag to distinguish the two cases.