### PR TITLE
Improved doc for KeyEvent kind field

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -642,6 +642,8 @@ pub struct KeyEvent {
     /// Additional key modifiers.
     pub modifiers: KeyModifiers,
     /// Kind of event.
+    ///
+    /// Only set if [`KeyboardEnhancementFlags::REPORT_EVENT_TYPES`] has been enabled with [`PushKeyboardEnhancementFlags`].
     pub kind: KeyEventKind,
     /// Keyboard state.
     ///


### PR DESCRIPTION
When using crossterm I was confused whey the KeyEventKind was not working, even though I was referring to the docs. I missed a link for to KeyboardEnhancementFlags.