### PR TITLE
SetCursorStyle improvements

### DIFF
--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -328,13 +328,11 @@ impl Command for Show {
 }
 
 /// A command that enables blinking of the terminal cursor.
-///
-/// See `SetCursorStyle` which is more advanced and better supported.
-///
+/// 
 /// # Notes
 ///
 /// - Some Unix terminals (ex: GNOME and Konsole) as well as Windows versions lower than Windows 10 do not support this functionality.
-///   Use SetCursorStyle for better cross-compatibility.
+///   Use `SetCursorStyle` for better cross-compatibility.
 /// - Commands must be executed/queued for execution otherwise they do nothing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct EnableBlinking;
@@ -350,12 +348,10 @@ impl Command for EnableBlinking {
 
 /// A command that disables blinking of the terminal cursor.
 ///
-/// See `SetCursorStyle` which is more advanced and better supported.
-///
 /// # Notes
 ///
 /// - Some Unix terminals (ex: GNOME and Konsole) as well as Windows versions lower than Windows 10 do not support this functionality.
-///   Use SetCursorStyle for better cross-compatibility.
+///   Use `SetCursorStyle` for better cross-compatibility.
 /// - Commands must be executed/queued for execution otherwise they do nothing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DisableBlinking;

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -333,9 +333,7 @@ impl Command for Show {
 ///
 /// # Notes
 ///
-/// - Some Unix terminals (ex: GNOME and Konsole) do not support this functionality.
-///   Use SetCursorStyle for better cross-compatibility.
-/// - Windows versions lower than Windows 10 do not support this functionality.
+/// - Some Unix terminals (ex: GNOME and Konsole) as well as Windows versions lower than Windows 10 do not support this functionality.
 ///   Use SetCursorStyle for better cross-compatibility.
 /// - Commands must be executed/queued for execution otherwise they do nothing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -356,9 +354,7 @@ impl Command for EnableBlinking {
 ///
 /// # Notes
 ///
-/// - Some Unix terminals (ex: GNOME and Konsole) do not support this functionality.
-///   Use SetCursorStyle for better cross-compatibility.
-/// - Windows versions lower than Windows 10 do not support this functionality.
+/// - Some Unix terminals (ex: GNOME and Konsole) as well as Windows versions lower than Windows 10 do not support this functionality.
 ///   Use SetCursorStyle for better cross-compatibility.
 /// - Commands must be executed/queued for execution otherwise they do nothing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -333,7 +333,10 @@ impl Command for Show {
 ///
 /// # Notes
 ///
+/// - Some Unix terminals (ex: GNOME and Konsole) do not support this functionality.
+///   Use SetCursorStyle for better cross-compatibility.
 /// - Windows versions lower than Windows 10 do not support this functionality.
+///   Use SetCursorStyle for better cross-compatibility.
 /// - Commands must be executed/queued for execution otherwise they do nothing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct EnableBlinking;
@@ -353,7 +356,10 @@ impl Command for EnableBlinking {
 ///
 /// # Notes
 ///
+/// - Some Unix terminals (ex: GNOME and Konsole) do not support this functionality.
+///   Use SetCursorStyle for better cross-compatibility.
 /// - Windows versions lower than Windows 10 do not support this functionality.
+///   Use SetCursorStyle for better cross-compatibility.
 /// - Commands must be executed/queued for execution otherwise they do nothing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DisableBlinking;
@@ -393,13 +399,13 @@ pub enum SetCursorStyle {
 impl Command for SetCursorStyle {
     fn write_ansi(&self, f: &mut impl fmt::Write) -> fmt::Result {
         match self {
-            SetCursorStyle::DefaultUserShape => f.write_str("\x1b[?12h\x1b[0 q"),
-            SetCursorStyle::BlinkingBlock => f.write_str("\x1b[?12h\x1b[1 q"),
-            SetCursorStyle::SteadyBlock => f.write_str("\x1b[?12l\x1b[2 q"),
-            SetCursorStyle::BlinkingUnderScore => f.write_str("\x1b[?12h\x1b[3 q"),
-            SetCursorStyle::SteadyUnderScore => f.write_str("\x1b[?12l\x1b[4 q"),
-            SetCursorStyle::BlinkingBar => f.write_str("\x1b[?12h\x1b[5 q"),
-            SetCursorStyle::SteadyBar => f.write_str("\x1b[?12l\x1b[6 q"),
+            SetCursorStyle::DefaultUserShape => f.write_str("\x1b[0 q"),
+            SetCursorStyle::BlinkingBlock => f.write_str("\x1b[1 q"),
+            SetCursorStyle::SteadyBlock => f.write_str("\x1b[2 q"),
+            SetCursorStyle::BlinkingUnderScore => f.write_str("\x1b[3 q"),
+            SetCursorStyle::SteadyUnderScore => f.write_str("\x1b[4 q"),
+            SetCursorStyle::BlinkingBar => f.write_str("\x1b[5 q"),
+            SetCursorStyle::SteadyBar => f.write_str("\x1b[6 q"),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,15 +41,14 @@
 //! - Module [`cursor`](cursor/index.html)
 //!   - Visibility - [`Show`](cursor/struct.Show.html), [`Hide`](cursor/struct.Hide.html)
 //!   - Appearance - [`EnableBlinking`](cursor/struct.EnableBlinking.html),
-//!     [`DisableBlinking`](cursor/struct.DisableBlinking.html)
+//!     [`DisableBlinking`](cursor/struct.DisableBlinking.html),
+//!     [`SetCursorStyle`](cursor/enum.SetCursorStyle.html)
 //!   - Position -
 //!     [`SavePosition`](cursor/struct.SavePosition.html), [`RestorePosition`](cursor/struct.RestorePosition.html),
 //!     [`MoveUp`](cursor/struct.MoveUp.html), [`MoveDown`](cursor/struct.MoveDown.html),
 //!     [`MoveLeft`](cursor/struct.MoveLeft.html), [`MoveRight`](cursor/struct.MoveRight.html),
 //!     [`MoveTo`](cursor/struct.MoveTo.html), [`MoveToColumn`](cursor/struct.MoveToColumn.html),[`MoveToRow`](cursor/struct.MoveToRow.html),
 //!     [`MoveToNextLine`](cursor/struct.MoveToNextLine.html), [`MoveToPreviousLine`](cursor/struct.MoveToPreviousLine.html)
-//!    - Shape -
-//!      [`SetCursorShape`](cursor/struct.SetCursorShape.html)
 //! - Module [`event`](event/index.html)
 //!   - Keyboard events -
 //!     [`PushKeyboardEnhancementFlags`](event/struct.PushKeyboardEnhancementFlags.html),


### PR DESCRIPTION
Followup to #742

- Added a note to `EnableBlinking` and `DisableBlinking` to warn of cross-compatibility issues.
- Removed "It uses two types of escape codes, one to control blinking, and the other the shape." because it's false. One escape code controls shape+blinking and the other was just a fall-back for blinking.
- Removed the fall-back escape codes since during my tests on different terminals/OS a didn't find any occurrence were they would be needed.
- Updated the doc.