### PR TITLE
Derived copy and clone for SetCursorStyle.

### DIFF
--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -371,6 +371,7 @@ impl Command for DisableBlinking {
 /// # Note
 ///
 /// - Commands must be executed/queued for execution otherwise they do nothing.
+#[derive(Clone, Copy)]
 pub enum SetCursorStyle {
     /// Default cursor shape configured by the user.
     DefaultUserShape,


### PR DESCRIPTION
Just a simple change, I needed to clone a `SetCursorStyle` struct in my own code, this lets me do that.