### PR TITLE
Remove early return in keyboard enhancement check

### DIFF
--- a/src/terminal/sys/unix.rs
+++ b/src/terminal/sys/unix.rs
@@ -131,7 +131,6 @@ fn read_supports_keyboard_enhancement_raw() -> Result<bool> {
         let mut stdout = io::stdout();
         stdout.write_all(QUERY)?;
         stdout.flush()?;
-        return Ok(false);
     }
 
     loop {


### PR DESCRIPTION
This block in the `if` sends the query over stdout if the query couldn't be sent over `/dev/tty` successfully. If we send it over stdout we should still query for the response though: the early return prevents that so the response to the query might end up not being consumed.

This fixes detection for me on Linux. I will test with macOS as well. (Edit: looks good on macOS too)