### PR TITLE
Implement "report alternate keys" from the Kitty Keyboard Protocol

### DIFF
--- a/examples/event-read.rs
+++ b/examples/event-read.rs
@@ -81,6 +81,7 @@ fn main() -> Result<()> {
             PushKeyboardEnhancementFlags(
                 KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
                     | KeyboardEnhancementFlags::REPORT_ALL_KEYS_AS_ESCAPE_CODES
+                    | KeyboardEnhancementFlags::REPORT_ALTERNATE_KEYS
                     | KeyboardEnhancementFlags::REPORT_EVENT_TYPES
             )
         )?;

--- a/src/event.rs
+++ b/src/event.rs
@@ -319,10 +319,9 @@ bitflags! {
         /// [`KeyEventKind::Release`] when keys are autorepeated or released.
         const REPORT_EVENT_TYPES = 0b0000_0010;
         // Send [alternate keycodes](https://sw.kovidgoyal.net/kitty/keyboard-protocol/#key-codes)
-        // in addition to the base keycode.
-        //
-        // *Note*: these are not yet supported by crossterm.
-        // const REPORT_ALTERNATE_KEYS = 0b0000_0100;
+        // in addition to the base keycode. The alternate keycode overrides the base keycode in
+        // resulting `KeyEvent`s.
+        const REPORT_ALTERNATE_KEYS = 0b0000_0100;
         /// Represent all keyboard events as CSI-u sequences. This is required to get repeat/release
         /// events for plain-text keys.
         const REPORT_ALL_KEYS_AS_ESCAPE_CODES = 0b0000_1000;


### PR DESCRIPTION
The "report alternate keys" part of the Kitty keyboard protocol will send an additional codepoint containing the "shifted" version of a key based on the keyboard layout. This is useful for downstream applications which set up keybindings based on symbols instead of exact keys being pressed.

For example, underscore (_) with the Alt modifier is sent as minus (-) with Alt and Shift modifiers. A terminal will send the underscore codepoint as an alternate though, and we can use that information and the presence of the Shift modifier to resolve the symbol. Other examples are `A-(` (sent as `A-S-9`) and `A-)` (sent as `A-S-0`).

This change allows pushing the "report alternate keys" flag and overwrites the keycode and modifiers for any shifted keys sent by the terminal.

This alternate key handling is the same as Kakoune's: https://github.com/mawww/kakoune/blob/eb0e9831330d3b1e1d3ddb2bc789000706e6e445/src/terminal_ui.cc#L804-L813