### PR TITLE
Make direct winapi deps optional

### DIFF
--- a/.github/workflows/crossterm_test.yml
+++ b/.github/workflows/crossterm_test.yml
@@ -63,8 +63,12 @@ jobs:
       run: cargo test --all-features -- --nocapture --test-threads 1
       continue-on-error: ${{ matrix.can-fail }}
     - name: Test no default features
+      if: matrix.os != 'windows-2019'
       run: cargo test --no-default-features -- --nocapture --test-threads 1
       continue-on-error: ${{ matrix.can-fail }}
+    - name: Test no default features with windows feature enabled
+      if: matrix.os == 'windows-2019'
+      run: cargo test --no-default-features --features windows -- --nocapture --test-threads 1
     - name: Test Packaging
       if: matrix.rust == 'stable'
       run: cargo package

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ all-features = true
 # Features
 #
 [features]
-default = ["bracketed-paste"]
+default = ["bracketed-paste", "crossterm_winapi"]
 bracketed-paste = []
 event-stream = ["futures-core"]
 use-dev-tty = ["filedescriptor"]
@@ -50,7 +50,7 @@ version = "0.3.9"
 features = ["winuser", "winerror"]
 
 [target.'cfg(windows)'.dependencies]
-crossterm_winapi = "0.9"
+crossterm_winapi = { version = "0.9", optional = true }
 
 #
 # UNIX dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,8 @@ all-features = true
 # Features
 #
 [features]
-default = ["bracketed-paste", "crossterm_winapi"]
+default = ["bracketed-paste", "windows"]
+windows = ["winapi", "crossterm_winapi"]
 bracketed-paste = []
 event-stream = ["futures-core"]
 use-dev-tty = ["filedescriptor"]
@@ -48,6 +49,7 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 [target.'cfg(windows)'.dependencies.winapi]
 version = "0.3.9"
 features = ["winuser", "winerror"]
+optional = true
 
 [target.'cfg(windows)'.dependencies]
 crossterm_winapi = { version = "0.9", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -257,3 +257,13 @@ pub mod ansi_support;
 mod command;
 mod error;
 pub(crate) mod macros;
+
+#[cfg(all(windows, not(feature = "windows")))]
+compile_error!("Compiling on Windows with \"windows\" feature disabled. Feature \"windows\" should only be disabled when project will never be compiled on Windows.");
+
+#[cfg(all(winapi, not(feature = "winapi")))]
+compile_error!("Compiling on Windows with \"winapi\" feature disabled. Feature \"winapi\" should only be disabled when project will never be compiled on Windows.");
+
+#[cfg(all(crossterm_winapi, not(feature = "crossterm_winapi")))]
+compile_error!("Compiling on Windows with \"crossterm_winapi\" feature disabled. Feature \"crossterm_winapi\" should only be disabled when project will never be compiled on Windows.");
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,4 +266,3 @@ compile_error!("Compiling on Windows with \"winapi\" feature disabled. Feature \
 
 #[cfg(all(crossterm_winapi, not(feature = "crossterm_winapi")))]
 compile_error!("Compiling on Windows with \"crossterm_winapi\" feature disabled. Feature \"crossterm_winapi\" should only be disabled when project will never be compiled on Windows.");
-


### PR DESCRIPTION
This is to make building easier on platforms like Yocto so we can actually remove it from the calculated dependencies. Would address #766 .