### PR TITLE
Fix examples on windows

### DIFF
--- a/examples/interactive-demo/src/main.rs
+++ b/examples/interactive-demo/src/main.rs
@@ -2,6 +2,7 @@
 
 use std::io::{self, Write};
 
+use crossterm::event::KeyEventKind;
 pub use crossterm::{
     cursor,
     event::{self, Event, KeyCode, KeyEvent},
@@ -80,7 +81,9 @@ pub fn read_char() -> Result<char> {
     loop {
         if let Ok(Event::Key(KeyEvent {
             code: KeyCode::Char(c),
-            ..
+            kind: KeyEventKind::Press,
+            modifiers: _,
+            state: _,
         })) = event::read()
         {
             return Ok(c);

--- a/examples/interactive-demo/src/main.rs
+++ b/examples/interactive-demo/src/main.rs
@@ -62,7 +62,10 @@ where
             '3' => test::attribute::run(w)?,
             '4' => test::event::run(w)?,
             '5' => test::synchronized_output::run(w)?,
-            'q' => break,
+            'q' => {
+                execute!(w, cursor::SetCursorStyle::DefaultUserShape).unwrap();
+                break;
+            }
             _ => {}
         };
     }

--- a/src/event/sys/windows/parse.rs
+++ b/src/event/sys/windows/parse.rs
@@ -290,11 +290,7 @@ fn parse_key_event_record(key_event: &KeyEventRecord) -> Option<WindowsKeyEvent>
             KeyEventKind::Release
         };
         let key_event = KeyEvent::new_with_kind(key_code, modifiers, kind);
-        if key_event
-            != KeyEvent::new_with_kind(KeyCode::Enter, KeyModifiers::NONE, KeyEventKind::Release)
-        {
             return Some(WindowsKeyEvent::KeyEvent(key_event));
-        }
     }
 
     None

--- a/src/event/sys/windows/parse.rs
+++ b/src/event/sys/windows/parse.rs
@@ -290,7 +290,11 @@ fn parse_key_event_record(key_event: &KeyEventRecord) -> Option<WindowsKeyEvent>
             KeyEventKind::Release
         };
         let key_event = KeyEvent::new_with_kind(key_code, modifiers, kind);
-        return Some(WindowsKeyEvent::KeyEvent(key_event));
+        if key_event
+            != KeyEvent::new_with_kind(KeyCode::Enter, KeyModifiers::NONE, KeyEventKind::Release)
+        {
+            return Some(WindowsKeyEvent::KeyEvent(key_event));
+        }
     }
 
     None

--- a/src/event/sys/windows/parse.rs
+++ b/src/event/sys/windows/parse.rs
@@ -290,7 +290,7 @@ fn parse_key_event_record(key_event: &KeyEventRecord) -> Option<WindowsKeyEvent>
             KeyEventKind::Release
         };
         let key_event = KeyEvent::new_with_kind(key_code, modifiers, kind);
-            return Some(WindowsKeyEvent::KeyEvent(key_event));
+        return Some(WindowsKeyEvent::KeyEvent(key_event));
     }
 
     None


### PR DESCRIPTION
Hey so the examples/demos have been broken since I found this crate, this stops "double presses" from happening by only looking for presses instead of all events. It seems to make demos work in conhost, windows terminal, and wezterm.

Edit: the "release" event does not seem to appear on cmd, so the problem might not be crossterm and I removed this hack.

Fixes https://github.com/crossterm-rs/crossterm/issues/759, closes https://github.com/crossterm-rs/crossterm/issues/772, closes https://github.com/crossterm-rs/crossterm/issues/769

Related issue: https://github.com/crossterm-rs/crossterm/issues/752

Also I had a problem where rust-analyzer didn't work in the `interactive-demo` sub-crate, it just shows a message "file not included in module tree". I had to move the folder out of crossterm and change the path to it in order to make it work. I already tried a bunch of stuff like changing where I open the folder in helix etc. Anyone else have this?