### PR TITLE
Add support for scrolling left and right.

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -575,6 +575,10 @@ pub enum MouseEventKind {
     ScrollDown,
     /// Scrolled mouse wheel upwards (away from the user).
     ScrollUp,
+    /// Scrolled mouse wheel left (mostly on a laptop touchpad).
+    ScrollLeft,
+    /// Scrolled mouse wheel right (mostly on a laptop touchpad).
+    ScrollRight,
 }
 
 /// Represents a mouse button.

--- a/src/event/sys/unix/parse.rs
+++ b/src/event/sys/unix/parse.rs
@@ -788,6 +788,8 @@ fn parse_cb(cb: u8) -> io::Result<(MouseEventKind, KeyModifiers)> {
         (3, true) | (4, true) | (5, true) => MouseEventKind::Moved,
         (4, false) => MouseEventKind::ScrollUp,
         (5, false) => MouseEventKind::ScrollDown,
+        (6, false) => MouseEventKind::ScrollLeft,
+        (7, false) => MouseEventKind::ScrollRight,
         // We do not support other buttons.
         _ => return Err(could_not_parse_event_error()),
     };

--- a/src/event/sys/windows/parse.rs
+++ b/src/event/sys/windows/parse.rs
@@ -366,7 +366,7 @@ fn parse_mouse_event_record(
             } else {
                 None
             }
-        }, 
+        }
         _ => None,
     };
 

--- a/src/event/sys/windows/parse.rs
+++ b/src/event/sys/windows/parse.rs
@@ -358,7 +358,15 @@ fn parse_mouse_event_record(
             }
         }
         EventFlags::DoubleClick => None, // double click not supported by unix terminals
-        EventFlags::MouseHwheeled => None, // horizontal scroll not supported by unix terminals
+        EventFlags::MouseHwheeled => {
+            if button_state.scroll_left() {
+                Some(MouseEventKind::ScrollLeft)
+            } else if button_state.scroll_right() {
+                Some(MouseEventKind::ScrollRight)
+            } else {
+                None
+            }
+        }, 
         _ => None,
     };
 


### PR DESCRIPTION
crossterm does not currently support left and right scrolling. This PR fixes that.