### PR TITLE
Specify and document MSRV for 0.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
 
 - Remove `SetCursorShape` in favour of `SetCursorStyle`.  (#742)
 - Make Windows resize event match `terminal::size` (#714)
+- Rust 1.58 or later is now required.
+
 # Version 0.25.0
 BREAKING: `Copy` trait is removed from `Event`, you can keep it by removing the "bracked-paste" feature flag. However this flag might be standardized in the future.
 We removed the `Copy` from `Event` because the new `Paste` event, which contains a pasted string into the terminal, which is a non-copy string.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["event", "color", "cli", "input", "terminal"]
 exclude = ["target", "Cargo.lock"]
 readme = "README.md"
 edition = "2021"
+rust-version = "1.58.0"
 categories = ["command-line-interface", "command-line-utilities"]
 
 [lib]


### PR DESCRIPTION
As of 318f810a39a7d45af2068eb97a255cdfa18282e8, crossterm uses RFC 2795 implicit named arguments, which shipped in Rust 1.58.