### PR TITLE
Add style::force_color_output() API to override NO_COLOR.

### DIFF
--- a/src/style.rs
+++ b/src/style.rs
@@ -166,6 +166,18 @@ pub fn available_color_count() -> u16 {
         .unwrap_or(8)
 }
 
+/// Forces colored output on or off globally, overriding NO_COLOR.
+///
+/// # Notes
+///
+/// crossterm supports NO_COLOR (https://no-color.org/) to disabled colored output.
+///
+/// This API allows applications to override that behavior and force colorized output
+/// even if NO_COLOR is set.
+pub fn force_color_output(enabled: bool) {
+    Colored::set_ansi_color_disabled(!enabled)
+}
+
 /// A command that sets the the foreground color.
 ///
 /// See [`Color`](enum.Color.html) for more info.

--- a/src/style/types/colored.rs
+++ b/src/style/types/colored.rs
@@ -86,7 +86,6 @@ impl Colored {
         ANSI_COLOR_DISABLED.load(Ordering::SeqCst)
     }
 
-    #[cfg(test)]
     pub fn set_ansi_color_disabled(val: bool) {
         // Force the one-time initializer to run.
         _ = Self::ansi_color_disabled_memoized();


### PR DESCRIPTION
As per comments by @Piturnah in https://github.com/crossterm-rs/crossterm/pull/782#issuecomment-1654742215 we should provide an API to override the NO_COLOR setting.