### PR TITLE
Document addition of `KeyEventKind::Release` as breaking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@
 ## Added ⭐
 
 - Add `SetCursorStyle` to set the cursor apearance and visibility. (#742)
-- Add key release event for windows. (#745)
 - Add a function to check if kitty keyboard enhancement protocol is available. (#732)
 - Add filedescriptors poll in order to move away from mio in the future (can be used via `use-dev-tty`). (#735)
 
@@ -22,9 +21,10 @@
 - Improved parsing of event types/modifiers with certain keys for kitty protocol. (#716)
 
 ## Breaking ⚠️
-
 - Remove `SetCursorShape` in favour of `SetCursorStyle`.  (#742)
 - Make Windows resize event match `terminal::size` (#714)
+- Add key release event for windows. (#745)
+
 # Version 0.25.0
 BREAKING: `Copy` trait is removed from `Event`, you can keep it by removing the "bracked-paste" feature flag. However this flag might be standardized in the future.
 We removed the `Copy` from `Event` because the new `Paste` event, which contains a pasted string into the terminal, which is a non-copy string.


### PR DESCRIPTION
This change in 0.26 broke my project since I was doing some behaviour based on any key event, so when `KeyEventKind::Release` was implemented for Windows it caused the behaviour to change (double event firing)

Based on #797 it seems this may be a common issue, so I think it should be moved in the change notes to a breaking change so people have more of a head's up.

By the way, thank you for all the incredible work on this library!

**Edit:** Just seen #778, seems like a great idea