### PR TITLE
Add `CSI 14 t` sequence support

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -947,6 +947,9 @@ pub(crate) enum InternalEvent {
     /// A cursor position (`col`, `row`).
     #[cfg(unix)]
     CursorPosition(u16, u16),
+    /// Terminal window size in pixels (`width`, `height`).
+    #[cfg(unix)]
+    WindowSize(u16, u16),
     /// The progressive keyboard enhancement flags enabled by the terminal.
     #[cfg(unix)]
     KeyboardEnhancementFlags(KeyboardEnhancementFlags),

--- a/src/event/filter.rs
+++ b/src/event/filter.rs
@@ -19,6 +19,17 @@ impl Filter for CursorPositionFilter {
 
 #[cfg(unix)]
 #[derive(Debug, Clone)]
+pub(crate) struct WindowSizeFilter;
+
+#[cfg(unix)]
+impl Filter for WindowSizeFilter {
+    fn eval(&self, event: &InternalEvent) -> bool {
+        matches!(*event, InternalEvent::WindowSize(_, _))
+    }
+}
+
+#[cfg(unix)]
+#[derive(Debug, Clone)]
 pub(crate) struct KeyboardEnhancementFlagsFilter;
 
 #[cfg(unix)]
@@ -76,12 +87,19 @@ mod tests {
     use super::{
         super::Event, CursorPositionFilter, EventFilter, Filter, InternalEvent,
         InternalEventFilter, KeyboardEnhancementFlagsFilter, PrimaryDeviceAttributesFilter,
+        WindowSizeFilter,
     };
 
     #[test]
     fn test_cursor_position_filter_filters_cursor_position() {
         assert!(!CursorPositionFilter.eval(&InternalEvent::Event(Event::Resize(10, 10))));
         assert!(CursorPositionFilter.eval(&InternalEvent::CursorPosition(0, 0)));
+    }
+
+    #[test]
+    fn test_window_size_filter_filters_window_size() {
+        assert!(!WindowSizeFilter.eval(&InternalEvent::Event(Event::Resize(10, 10))));
+        assert!(WindowSizeFilter.eval(&InternalEvent::WindowSize(0, 0)));
     }
 
     #[test]
@@ -105,11 +123,13 @@ mod tests {
     fn test_event_filter_filters_events() {
         assert!(EventFilter.eval(&InternalEvent::Event(Event::Resize(10, 10))));
         assert!(!EventFilter.eval(&InternalEvent::CursorPosition(0, 0)));
+        assert!(!EventFilter.eval(&InternalEvent::WindowSize(0, 0)));
     }
 
     #[test]
     fn test_event_filter_filters_internal_events() {
         assert!(InternalEventFilter.eval(&InternalEvent::Event(Event::Resize(10, 10))));
         assert!(InternalEventFilter.eval(&InternalEvent::CursorPosition(0, 0)));
+        assert!(InternalEventFilter.eval(&InternalEvent::WindowSize(0, 0)));
     }
 }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -154,6 +154,16 @@ pub fn window_size() -> io::Result<WindowSize> {
     sys::window_size()
 }
 
+/// Returns the terminal size `(width, height)`.
+///
+/// Some terminals do not implement the `ioctl` system call to get the size in pixels,
+/// but support it by sending a `CSI 14 t` sequence, this function returns the reported pixel size.
+#[cfg(unix)]
+#[cfg(feature = "events")]
+pub fn window_size_csi(timeout: std::time::Duration) -> io::Result<(u16, u16)> {
+    sys::read_window_size(timeout)
+}
+
 /// Disables line wrapping.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DisableLineWrap;

--- a/src/terminal/sys.rs
+++ b/src/terminal/sys.rs
@@ -2,6 +2,9 @@
 
 #[cfg(unix)]
 #[cfg(feature = "events")]
+pub use self::unix::read_window_size;
+#[cfg(unix)]
+#[cfg(feature = "events")]
 pub use self::unix::supports_keyboard_enhancement;
 #[cfg(unix)]
 pub(crate) use self::unix::{


### PR DESCRIPTION
I noticed that https://github.com/crossterm-rs/crossterm/pull/790 is merged, but some terminals (e.g. VSCode, [Hyper canary](https://github.com/vercel/hyper/issues/7375#issuecomment-1668365392) which are [`node-pty`](https://github.com/microsoft/node-pty) based) do not implement the `ioctl` system call to get the terminal's width and height -- always zeros are returned, but they can get the correct pixel size by `CSI 14 t`.

I'm working on a [terminal file manager](https://github.com/sxyazi/yazi) where getting the correct width and height is critical for resizing images to be previewed, and I'll continue to add tests to the PR if it makes sense!
