### PR TITLE
Remove unsafe and unnecessary `size` argument from `FileDesc::read()`

### DIFF
--- a/src/event/source/unix/mio.rs
+++ b/src/event/source/unix/mio.rs
@@ -93,7 +93,7 @@ impl EventSource for UnixInternalEventSource {
                 match token {
                     TTY_TOKEN => {
                         loop {
-                            match self.tty_fd.read(&mut self.tty_buffer, TTY_BUFFER_SIZE) {
+                            match self.tty_fd.read(&mut self.tty_buffer) {
                                 Ok(read_count) => {
                                     if read_count > 0 {
                                         self.parser.advance(

--- a/src/terminal/sys/file_descriptor.rs
+++ b/src/terminal/sys/file_descriptor.rs
@@ -29,12 +29,12 @@ impl FileDesc {
         FileDesc { fd, close_on_drop }
     }
 
-    pub fn read(&self, buffer: &mut [u8], size: usize) -> io::Result<usize> {
+    pub fn read(&self, buffer: &mut [u8]) -> io::Result<usize> {
         let result = unsafe {
             libc::read(
                 self.fd,
                 buffer.as_mut_ptr() as *mut libc::c_void,
-                size as size_t,
+                buffer.len() as size_t,
             )
         };
 


### PR DESCRIPTION
The `size` argument to `FileDesc::read()` is not checked against the length of the buffer, so `libc::read()` could end up writing past the buffer if we passed a size that's too large. However, we always pass exactly the size of the buffer, so that doesn't happen. Let's just remove the argument since it's not currently needed, thereby removing the risk of bugs if the function is used incorrectly by future callers.

This came up in review of `unsafe` Rust code at my company.