### PR TITLE
Update README.md: fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ features = ["event-stream"]
 | `filedescriptor` | Use raw filedescriptor for all events rather then mio dependency |
 
 
-To use crossterm as a very tin layer you can disable the `events` feature or use `filedescriptor` feature. 
+To use crossterm as a very thin layer you can disable the `events` feature or use `filedescriptor` feature. 
 This can disable `mio` / `signal-hook` / `signal-hook-mio` dependencies.
 
 ### Dependency Justification


### PR DESCRIPTION
Word `tin` does not seem appropriate in this context. In changed it to `thin` since it fits better in the context and better describes this `crossterm` library.