### PR TITLE
Fix `poll(Duration::ZERO)` with `use-dev-tty`

### DIFF
--- a/src/event/source/unix/tty.rs
+++ b/src/event/source/unix/tty.rs
@@ -116,6 +116,11 @@ impl EventSource for UnixInternalEventSource {
             make_pollfd(&self.wake_pipe.receiver),
         ];
 
+        // check if there are buffered events from the last read
+        if let Some(event) = self.parser.next() {
+            return Ok(Some(event));
+        }
+
         while timeout.leftover().map_or(true, |t| !t.is_zero()) {
             // check if there are buffered events from the last read
             if let Some(event) = self.parser.next() {


### PR DESCRIPTION
This PR fixes the incorrect behaviour of `crossterm::event::poll(Duration::ZERO)` when `use-dev-tty` is used.

Previously, events that were already buffered were only checked if some amount of time was left before the timeout, which is never the case when `Duration::ZERO` is used, which did lead to events being buffered but unreported.  

Now, we always check buffered events at least once, regardless of timeout.

**Fixes #839.**