### PR TITLE
fix docs for window_size

### DIFF
--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -130,13 +130,19 @@ pub fn disable_raw_mode() -> io::Result<()> {
     sys::disable_raw_mode()
 }
 
-/// Returns the terminal size `(columns, rows)`.
+/// Returns the terminal size in `(columns, rows)`.
 ///
 /// The top left cell is represented `(1, 1)`.
 pub fn size() -> io::Result<(u16, u16)> {
     sys::size()
 }
 
+/// Terminal size in both `(columns, rows)` and pixel `(width, height)`.
+///
+/// The returned width and height by the terminal may not be reliable or default to 0.
+/// For linux, [tty_ioctl] specifically the `width` and `height` fields are documented as "unused".
+///
+/// [tty_ioctl]: https://man7.org/linux/man-pages/man4/tty_ioctl.4.html
 #[derive(Debug)]
 pub struct WindowSize {
     pub rows: u16,
@@ -145,11 +151,10 @@ pub struct WindowSize {
     pub height: u16,
 }
 
-/// Returns the terminal size `[WindowSize]`.
+/// Returns the terminal `(columns,rows)` and also pixel sizes as [WindowSize].
 ///
-/// The width and height in pixels may not be reliably implemented or default to 0.
-/// For unix, https://man7.org/linux/man-pages/man4/tty_ioctl.4.html documents them as "unused".
-/// For windows it is not implemented.
+/// All fields in the struct may default to zero without returning en error.
+/// On windows this **always** returns an error.
 pub fn window_size() -> io::Result<WindowSize> {
     sys::window_size()
 }


### PR DESCRIPTION
1. Fix external link formatting.
2. Be specific about all fields possibly being zero, and the pixel fields being documented for **linux** as "unused".
3. (I am not sure about TIOCGWINSZ bing posix).
4. Specify that `window_size()` always returns an error on windows.
5. Put the detailed docs in `WindowSize`.

@markus-bauer this addresses some points of your comment in #790 after it was merged. What do you suggest regarding windows not being supported? I have tried everything in that regard:
1. Getting the console font size, but it is in "logical units", so it would need the current DPI or something like that to get to the font pixel size, to ultimately get the window size by multiplying with `(columns,rows)`.
2. All of the [windows console API](https://learn.microsoft.com/en-us/windows/console/console-reference) only deals in `(columns,rows)`.
3. Using `GetClientRect`, which I almost thought would work, but even that gave me bogus values. Also seems a bit far off the track for a terminal library.

Perhaps this was a mistake, and `window_size()` should be removed from crossterm, after all it's not cross-platform now. Users who need the window size, on unix, can then just use some tty-ioctl lib, e.g. [rustix](https://docs.rs/rustix/latest/rustix/termios/fn.tcgetwinsize.html).