### PR TITLE
Fix minor formatting mistake

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -88,7 +88,7 @@ macro_rules! queue {
 /// execute!(stdout(), Print("sum:\n".to_string()));
 ///
 /// // will be executed directly
-/// execute!(stdout(), Print("1 + 1= ".to_string()), Print((1+1).to_string()));
+/// execute!(stdout(), Print("1 + 1 = ".to_string()), Print((1+1).to_string()));
 ///
 /// // ==== Output ====
 /// // sum:


### PR DESCRIPTION
The line `execute!(stdout(), Print("1 + 1= ".to_string()), Print((1+1).to_string()));` would print `1 + 1= 2`, however the output of the example, on line 95, is `1 + 1 = 2`