### PR TITLE
Implement Display for KeyCode and KeyModifiers

### DIFF
--- a/examples/key-display.rs
+++ b/examples/key-display.rs
@@ -1,0 +1,49 @@
+//! Demonstrates the display format of key events.
+//!
+//! This example demonstrates the display format of key events, which is useful for displaying in
+//! the help section of a terminal application.
+//!
+//! cargo run --example key-display
+
+use std::io;
+
+use crossterm::event::{KeyEventKind, KeyModifiers};
+use crossterm::{
+    event::{read, Event, KeyCode},
+    terminal::{disable_raw_mode, enable_raw_mode},
+};
+
+const HELP: &str = r#"Key display
+ - Press any key to see its display format
+ - Use Esc to quit
+"#;
+
+fn main() -> io::Result<()> {
+    println!("{}", HELP);
+    enable_raw_mode()?;
+    if let Err(e) = print_events() {
+        println!("Error: {:?}\r", e);
+    }
+    disable_raw_mode()?;
+    Ok(())
+}
+
+fn print_events() -> io::Result<()> {
+    loop {
+        let event = read()?;
+        match event {
+            Event::Key(event) if event.kind == KeyEventKind::Press => {
+                print!("Key pressed: ");
+                if event.modifiers != KeyModifiers::NONE {
+                    print!("{}+", event.modifiers);
+                }
+                println!("{}\r", event.code);
+                if event.code == KeyCode::Esc {
+                    break;
+                }
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
Partially addresses #792

In Ratatui apps using Crossterm, something we'd like to be able to generally provide approaches for is help screens that show the key bindings that will be used. The responsibility for displaying each keys properly most likely belongs in Crossterm rather than each application.

I've tried to make some reasonable choices about displaying the keys that match the target platform (e.g. on Mac, Backspace is Delete, Delete is Fwd Del, Enter is Return, Alt is Option, Ctrl is Control, Super is Command, and on Windows Super is the Windows key). These choices are backed by the style guidelines from Apple and Microsoft where possible and intuition where not (e.g. Next Track instead of Track Next).

It would be nice to be able to have used something like `strum`'s `Display` derive macro to make the implementation of this simple, but there currently isn't a way to make the format for the function keys (`F1`) or the media / modifier key variants work with that, so a more manual approach is taken.