### PR TITLE
Fix duplicate bit masks for caps lock and num lock

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -635,11 +635,11 @@ bitflags! {
         /// Caps Lock was enabled for this key event.
         ///
         /// **Note:** this is set for the initial press of Caps Lock itself.
-        const CAPS_LOCK = 0b0000_1000;
+        const CAPS_LOCK = 0b0000_0010;
         /// Num Lock was enabled for this key event.
         ///
         /// **Note:** this is set for the initial press of Num Lock itself.
-        const NUM_LOCK = 0b0000_1000;
+        const NUM_LOCK = 0b0000_0100;
         const NONE = 0b0000_0000;
     }
 }


### PR DESCRIPTION
I'm using the Kitty terminal emulator with crossterm's raw mode, `DISAMBIGUATE_ESCAPE_CODES` and `REPORT_ALL_KEYS_AS_ESCAPE_CODES`. I noticed that caps lock was always being reported as active via `event.state.contains(KeyEventState::CAPS_LOCK)`, even when toggling the key many times and restarting my program. Looking into crossterm's source, I found what looks like a simple copy/paste bug: `CAPS_LOCK` and `NUM_LOCK` both use the bit mask `0b000_1000`. `0b0000_0001` is used but `0b0000_0010` and `0b0000_0100` aren't, so I went ahead and assigned those sequentially instead. With this change, caps lock is being detected as expected. I haven't tested numlock (my current keyboard doesn't have it clearly labeled) but I expect this can only help.