### PR TITLE
docs: add tested platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ WARNING: Do not change following heading title as it's used in the URL by other 
     - Windows 8.1 (N)
 - Windows Terminal
     - Windows 10 x86_64 (Enterprise)
-    - Windows 11 arm64 (Enterprise, a virtual machine running on Macbook M1 Max with Parallel)
+    - Windows 11 arm64 (Enterprise, vm running on Macbook M1 Max with Parallel)
 - Ubuntu Desktop Terminal
-    - Ubuntu 23.04 x86_64 (a virtual machine running on Windows 10 x86_64 with VMWare Workstation)
+    - Ubuntu 23.04 x86_64 (vm running on Windows 10 x86_64 with VMWare Workstation)
     - Ubuntu 17.10
     - Pop!_OS ( Ubuntu ) 20.04
 - (Arch, Manjaro) KDE Konsole

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ WARNING: Do not change following heading title as it's used in the URL by other 
 - (Chrome OS) Crostini
 - Apple
     - macOS Monterey 12.7.1 (Intel-Chip)
-    - macOS Sonama 14.4 (Apple M1 Max, Silicon-Chip)
+    - macOS Sonama 14.4 (M1 Max, Apple Silicon-Chip)
 
 This crate supports all UNIX terminals and Windows terminals down to Windows 7; however, not all of the
 terminals have been tested. If you have used this library for a terminal other than the above list without

--- a/README.md
+++ b/README.md
@@ -70,7 +70,11 @@ WARNING: Do not change following heading title as it's used in the URL by other 
 - Console Host
     - Windows 10 (Pro)
     - Windows 8.1 (N)
+- Windows Terminal
+    - Windows 10 x86_64 (Enterprise)
+    - Windows 11 arm64 (Enterprise, virtual machine running on Macbook M1 Max with Parallel)
 - Ubuntu Desktop Terminal
+    - Ubuntu 23.04 x86_64 (Virtual machine running on Windows 10 x86_64 with VMWare Workstation)
     - Ubuntu 17.10
     - Pop!_OS ( Ubuntu ) 20.04
 - (Arch, Manjaro) KDE Konsole

--- a/README.md
+++ b/README.md
@@ -70,11 +70,7 @@ WARNING: Do not change following heading title as it's used in the URL by other 
 - Console Host
     - Windows 10 (Pro)
     - Windows 8.1 (N)
-- Windows Terminal (Preview)
-    - Windows 11 (Pro)
-    - Windows 10 x86_64 (Pro)
 - Ubuntu Desktop Terminal
-    - Ubuntu 23.04
     - Ubuntu 17.10
     - Pop!_OS ( Ubuntu ) 20.04
 - (Arch, Manjaro) KDE Konsole
@@ -84,7 +80,7 @@ WARNING: Do not change following heading title as it's used in the URL by other 
 - (Chrome OS) Crostini
 - Apple
     - macOS Monterey 12.7.1 (Intel-Chip)
-    - macOS 15.3.1 (Silicon-Chip, M1 Max)
+    - macOS Sonama 14.4 (Apple M1 Max, Silicon-Chip)
 
 This crate supports all UNIX terminals and Windows terminals down to Windows 7; however, not all of the
 terminals have been tested. If you have used this library for a terminal other than the above list without

--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ WARNING: Do not change following heading title as it's used in the URL by other 
     - Windows 8.1 (N)
 - Windows Terminal
     - Windows 10 x86_64 (Enterprise)
-    - Windows 11 arm64 (Enterprise, virtual machine running on Macbook M1 Max with Parallel)
+    - Windows 11 arm64 (Enterprise, a virtual machine running on Macbook M1 Max with Parallel)
 - Ubuntu Desktop Terminal
-    - Ubuntu 23.04 x86_64 (virtual machine running on Windows 10 x86_64 with VMWare Workstation)
+    - Ubuntu 23.04 x86_64 (a virtual machine running on Windows 10 x86_64 with VMWare Workstation)
     - Ubuntu 17.10
     - Pop!_OS ( Ubuntu ) 20.04
 - (Arch, Manjaro) KDE Konsole

--- a/README.md
+++ b/README.md
@@ -70,7 +70,11 @@ WARNING: Do not change following heading title as it's used in the URL by other 
 - Console Host
     - Windows 10 (Pro)
     - Windows 8.1 (N)
+- Windows Terminal (Preview)
+    - Windows 11 (Pro)
+    - Windows 10 x86_64 (Pro)
 - Ubuntu Desktop Terminal
+    - Ubuntu 23.04
     - Ubuntu 17.10
     - Pop!_OS ( Ubuntu ) 20.04
 - (Arch, Manjaro) KDE Konsole
@@ -80,6 +84,7 @@ WARNING: Do not change following heading title as it's used in the URL by other 
 - (Chrome OS) Crostini
 - Apple
     - macOS Monterey 12.7.1 (Intel-Chip)
+    - macOS 15.3.1 (Silicon-Chip, M1 Max)
 
 This crate supports all UNIX terminals and Windows terminals down to Windows 7; however, not all of the
 terminals have been tested. If you have used this library for a terminal other than the above list without

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ WARNING: Do not change following heading title as it's used in the URL by other 
     - Windows 10 x86_64 (Enterprise)
     - Windows 11 arm64 (Enterprise, virtual machine running on Macbook M1 Max with Parallel)
 - Ubuntu Desktop Terminal
-    - Ubuntu 23.04 x86_64 (Virtual machine running on Windows 10 x86_64 with VMWare Workstation)
+    - Ubuntu 23.04 x86_64 (virtual machine running on Windows 10 x86_64 with VMWare Workstation)
     - Ubuntu 17.10
     - Pop!_OS ( Ubuntu ) 20.04
 - (Arch, Manjaro) KDE Konsole

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ WARNING: Do not change following heading title as it's used in the URL by other 
     - Windows 10 x86_64 (Enterprise)
     - Windows 11 arm64 (Enterprise, vm running on Macbook M1 Max with Parallel)
 - Ubuntu Desktop Terminal
-    - Ubuntu 23.04 x86_64 (vm running on Windows 10 x86_64 with VMWare Workstation)
+    - Ubuntu 23.04 64-bit (vm running on Windows 10 x86_64 with VMWare Workstation)
     - Ubuntu 17.10
     - Pop!_OS ( Ubuntu ) 20.04
 - (Arch, Manjaro) KDE Konsole

--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ WARNING: Do not change following heading title as it's used in the URL by other 
     - Windows 8.1 (N)
 - Windows Terminal
     - Windows 10 x86_64 (Enterprise)
-    - Windows 11 arm64 (Enterprise, vm running on Macbook M1 Max with Parallel)
+    - Windows 11 arm64 (Enterprise)
 - Ubuntu Desktop Terminal
-    - Ubuntu 23.04 64-bit (vm running on Windows 10 x86_64 with VMWare Workstation)
+    - Ubuntu 23.04 64-bit
     - Ubuntu 17.10
     - Pop!_OS ( Ubuntu ) 20.04
 - (Arch, Manjaro) KDE Konsole


### PR DESCRIPTION
I run a very simple demo in below platforms (so only very limited API such as `execute!`, `Print`, `cursor`, `EnterAlternateScreen`, `terminal::size` is been used):

1. [x] macOS Sonama 14.4, Apple M1 Max, Silicon Chip.
2. [x] Windows 11 Enterprise 22H2, arm64, a virtual machine running in the macOS (above) with Parallel.
3. [x] Windows 10, x86_64, with Windows Terminal (is that a Console Host?)
4. [x] Ubuntu 23.04, x86_64 Desktop, a virtual machine running in the Windows 10 x86_64 (above) with VMWare Workstation.


Note: the checked ones are been manually tested.

Here's the demo source code: https://github.com/rsvim/rsvim/tree/chore-demo

Here's the screen recording:

https://github.com/crossterm-rs/crossterm/assets/6496887/f3440763-ae18-452b-98fd-cdd1c79a6a6e

