### PR TITLE
Use rustix instead of libc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ events = [
     "dep:signal-hook-mio",
 ] # Enables reading input/events from the system.
 serde = ["dep:serde", "bitflags/serde"] # Enables 'serde' for various types.
+rustix = ["dep:rustix"] # On Unix, enables using rustix as the underlying interface.
 
 #
 # Shared dependencies
@@ -73,15 +74,12 @@ crossterm_winapi = { version = "0.9.1", optional = true }
 [target.'cfg(unix)'.dependencies]
 signal-hook = { version = "0.3.17", optional = true }
 filedescriptor = { version = "0.8", optional = true }
+libc = { version = "0.2", default-features = false }
 mio = { version = "0.8", features = ["os-poll"], optional = true }
-<<<<<<< HEAD
 signal-hook-mio = { version = "0.2.3", features = [
     "support-v0_8",
 ], optional = true }
-=======
-signal-hook-mio = { version = "0.2.3", features = ["support-v0_8"], optional = true }
-rustix = { version = "0.38.0", default-features = false, features = ["std", "stdio", "termios"] }
->>>>>>> 4ca0c8e (feat: Use rustix instead of libc)
+rustix = { version = "0.38.0", default-features = false, features = ["std", "stdio", "termios"], optional = true }
 
 #
 # Dev dependencies (examples, ...)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["event", "color", "cli", "input", "terminal"]
 exclude = ["target", "Cargo.lock"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.58.0"
+rust-version = "1.63.0"
 categories = ["command-line-interface", "command-line-utilities"]
 
 [lib]
@@ -71,13 +71,17 @@ crossterm_winapi = { version = "0.9.1", optional = true }
 # UNIX dependencies
 #
 [target.'cfg(unix)'.dependencies]
-libc = "0.2"
 signal-hook = { version = "0.3.17", optional = true }
 filedescriptor = { version = "0.8", optional = true }
 mio = { version = "0.8", features = ["os-poll"], optional = true }
+<<<<<<< HEAD
 signal-hook-mio = { version = "0.2.3", features = [
     "support-v0_8",
 ], optional = true }
+=======
+signal-hook-mio = { version = "0.2.3", features = ["support-v0_8"], optional = true }
+rustix = { version = "0.38.0", default-features = false, features = ["std", "stdio", "termios"] }
+>>>>>>> 4ca0c8e (feat: Use rustix instead of libc)
 
 #
 # Dev dependencies (examples, ...)

--- a/src/event.rs
+++ b/src/event.rs
@@ -1150,7 +1150,6 @@ pub(crate) enum InternalEvent {
 #[cfg(test)]
 mod tests {
     use std::collections::hash_map::DefaultHasher;
-    use std::hash::{Hash, Hasher};
 
     use super::*;
     use KeyCode::*;

--- a/src/event/sys/unix/parse.rs
+++ b/src/event/sys/unix/parse.rs
@@ -863,8 +863,6 @@ pub(crate) fn parse_utf8_char(buffer: &[u8]) -> io::Result<Option<char>> {
 
 #[cfg(test)]
 mod tests {
-    use crate::event::{KeyEventState, KeyModifiers, MouseButton, MouseEvent};
-
     use super::*;
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,6 +249,8 @@ pub mod tty;
 pub mod ansi_support;
 mod command;
 pub(crate) mod macros;
+#[cfg(unix)]
+mod sys;
 
 #[cfg(all(windows, not(feature = "windows")))]
 compile_error!("Compiling on Windows with \"windows\" feature disabled. Feature \"windows\" should only be disabled when project will never be compiled on Windows.");

--- a/src/style/types/color.rs
+++ b/src/style/types/color.rs
@@ -1,7 +1,4 @@
-use std::{
-    convert::{AsRef, TryFrom},
-    str::FromStr,
-};
+use std::str::FromStr;
 
 #[cfg(feature = "serde")]
 use std::fmt;

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -1,0 +1,12 @@
+//! Interface to the C system library.
+//!
+//! This uses either rustix or libc.
+
+#[cfg(feature = "rustix")]
+pub(crate) use rustix::*;
+
+#[cfg(not(feature = "rustix"))]
+mod minirustix;
+
+#[cfg(not(feature = "rustix"))]
+pub(crate) use minirustix::*;

--- a/src/sys/minirustix.rs
+++ b/src/sys/minirustix.rs
@@ -71,13 +71,13 @@ pub(crate) mod termios {
     pub(crate) fn tcsetattr(
         fd: impl AsFd,
         optional: OptionalActions,
-        termios: &Termios
+        termios: &Termios,
     ) -> Result<()> {
         unsafe {
             cvt(libc::tcsetattr(
                 fd.as_fd().as_raw_fd(),
                 optional as _,
-                termios
+                termios,
             ))?;
 
             Ok(())

--- a/src/sys/minirustix.rs
+++ b/src/sys/minirustix.rs
@@ -1,0 +1,94 @@
+//! Emulates rustix's interface using libc.
+
+pub(crate) mod io {
+    use super::cvt;
+    use std::io::Result;
+    use std::os::unix::io::{AsFd, AsRawFd};
+
+    pub(crate) fn read(f: impl AsFd, buf: &mut [u8]) -> Result<usize> {
+        unsafe {
+            cvt(libc::read(
+                f.as_fd().as_raw_fd(),
+                buf.as_mut_ptr().cast(),
+                buf.len() as _,
+            ) as i32)
+            .map(|x| x as usize)
+        }
+    }
+}
+
+pub(crate) mod stdio {
+    use std::os::unix::io::BorrowedFd;
+
+    pub(crate) fn stdin() -> BorrowedFd<'static> {
+        unsafe { BorrowedFd::borrow_raw(libc::STDIN_FILENO) }
+    }
+
+    pub(crate) fn stdout() -> BorrowedFd<'static> {
+        unsafe { BorrowedFd::borrow_raw(libc::STDOUT_FILENO) }
+    }
+}
+
+pub(crate) mod termios {
+    use super::cvt;
+    use std::io::Result;
+    use std::mem::MaybeUninit;
+    use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd};
+
+    pub(crate) type Termios = libc::termios;
+    pub(crate) type Winsize = libc::winsize;
+
+    #[repr(u32)]
+    pub(crate) enum OptionalActions {
+        Now = 0,
+        // All others are unused by crossterm.
+    }
+
+    pub(crate) fn isatty(fd: BorrowedFd<'_>) -> bool {
+        unsafe { libc::isatty(fd.as_raw_fd()) != 0 }
+    }
+
+    pub(crate) fn tcgetwinsize(fd: impl AsFd) -> Result<Winsize> {
+        unsafe {
+            let mut buf = MaybeUninit::<Winsize>::uninit();
+            cvt(libc::ioctl(
+                fd.as_fd().as_raw_fd(),
+                libc::TIOCGWINSZ,
+                buf.as_mut_ptr(),
+            ))?;
+            Ok(buf.assume_init())
+        }
+    }
+
+    pub(crate) fn tcgetattr(fd: impl AsFd) -> Result<Termios> {
+        unsafe {
+            let mut buf = MaybeUninit::<Termios>::uninit();
+            cvt(libc::tcgetattr(fd.as_fd().as_raw_fd(), buf.as_mut_ptr()))?;
+            Ok(buf.assume_init())
+        }
+    }
+
+    pub(crate) fn tcsetattr(
+        fd: impl AsFd,
+        optional: OptionalActions,
+        termios: &Termios
+    ) -> Result<()> {
+        unsafe {
+            cvt(libc::tcsetattr(
+                fd.as_fd().as_raw_fd(),
+                optional as _,
+                termios
+            ))?;
+
+            Ok(())
+        }
+    }
+}
+
+fn cvt(res: i32) -> std::io::Result<i32> {
+    if res < 0 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(res)
+    }
+}

--- a/src/terminal/sys/file_descriptor.rs
+++ b/src/terminal/sys/file_descriptor.rs
@@ -1,6 +1,6 @@
+use crate::sys;
+use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, OwnedFd, RawFd};
 use std::{fs, io};
-
-use rustix::fd::{AsFd, AsRawFd, BorrowedFd, OwnedFd, RawFd};
 
 /// A file descriptor wrapper.
 ///
@@ -19,7 +19,7 @@ impl FileDesc {
             Self::Static(fd) => fd.as_fd(),
         };
 
-        let result = rustix::io::read(fd, buffer)?;
+        let result = sys::io::read(fd, buffer)?;
         Ok(result)
     }
 
@@ -49,8 +49,8 @@ impl AsRawFd for FileDesc {
 
 /// Creates a file descriptor pointing to the standard input or `/dev/tty`.
 pub fn tty_fd() -> io::Result<FileDesc> {
-    if rustix::termios::isatty(rustix::stdio::stdin()) {
-        Ok(FileDesc::Static(rustix::stdio::stdin()))
+    if sys::termios::isatty(sys::stdio::stdin()) {
+        Ok(FileDesc::Static(sys::stdio::stdin()))
     } else {
         Ok(FileDesc::Owned(
             fs::OpenOptions::new()

--- a/src/terminal/sys/unix.rs
+++ b/src/terminal/sys/unix.rs
@@ -4,16 +4,14 @@ use crate::terminal::{
     sys::file_descriptor::{tty_fd, FileDesc},
     WindowSize,
 };
-use libc::{
-    cfmakeraw, ioctl, tcgetattr, tcsetattr, termios as Termios, winsize, STDOUT_FILENO, TCSANOW,
-    TIOCGWINSZ,
-};
 use parking_lot::Mutex;
+use rustix::{
+    fd::AsFd,
+    termios::{Termios, Winsize},
+};
 use std::fs::File;
 
-use std::os::unix::io::{IntoRawFd, RawFd};
-
-use std::{io, mem, process};
+use std::{io, process};
 
 // Some(Termios) -> we're in the raw mode and this is the previous mode
 // None -> we're not in the raw mode
@@ -23,8 +21,8 @@ pub(crate) fn is_raw_mode_enabled() -> bool {
     TERMINAL_MODE_PRIOR_RAW_MODE.lock().is_some()
 }
 
-impl From<winsize> for WindowSize {
-    fn from(size: winsize) -> WindowSize {
+impl From<Winsize> for WindowSize {
+    fn from(size: Winsize) -> WindowSize {
         WindowSize {
             columns: size.ws_col,
             rows: size.ws_row,
@@ -36,27 +34,16 @@ impl From<winsize> for WindowSize {
 
 #[allow(clippy::useless_conversion)]
 pub(crate) fn window_size() -> io::Result<WindowSize> {
-    // http://rosettacode.org/wiki/Terminal_control/Dimensions#Library:_BSD_libc
-    let mut size = winsize {
-        ws_row: 0,
-        ws_col: 0,
-        ws_xpixel: 0,
-        ws_ypixel: 0,
-    };
-
-    let file = File::open("/dev/tty").map(|file| (FileDesc::new(file.into_raw_fd(), true)));
+    let file = File::open("/dev/tty").map(|file| FileDesc::Owned(file.into()));
     let fd = if let Ok(file) = &file {
-        file.raw_fd()
+        file.as_fd()
     } else {
         // Fallback to libc::STDOUT_FILENO if /dev/tty is missing
-        STDOUT_FILENO
+        rustix::stdio::stdout()
     };
 
-    if wrap_with_result(unsafe { ioctl(fd, TIOCGWINSZ.into(), &mut size) }).is_ok() {
-        return Ok(size.into());
-    }
-
-    Err(std::io::Error::last_os_error().into())
+    let size = rustix::termios::tcgetwinsize(fd)?;
+    Ok(size.into())
 }
 
 #[allow(clippy::useless_conversion)]
@@ -76,12 +63,11 @@ pub(crate) fn enable_raw_mode() -> io::Result<()> {
     }
 
     let tty = tty_fd()?;
-    let fd = tty.raw_fd();
-    let mut ios = get_terminal_attr(fd)?;
-    let original_mode_ios = ios;
+    let mut ios = get_terminal_attr(&tty)?;
+    let original_mode_ios = ios.clone();
 
-    raw_terminal_attr(&mut ios);
-    set_terminal_attr(fd, &ios)?;
+    ios.make_raw();
+    set_terminal_attr(&tty, &ios)?;
 
     // Keep it last - set the original mode only if we were able to switch to the raw mode
     *original_mode = Some(original_mode_ios);
@@ -99,7 +85,7 @@ pub(crate) fn disable_raw_mode() -> io::Result<()> {
 
     if let Some(original_mode_ios) = original_mode.as_ref() {
         let tty = tty_fd()?;
-        set_terminal_attr(tty.raw_fd(), original_mode_ios)?;
+        set_terminal_attr(&tty, original_mode_ios)?;
         // Keep it last - remove the original mode only if we were able to switch back
         *original_mode = None;
     }
@@ -214,27 +200,12 @@ fn tput_size() -> Option<(u16, u16)> {
     }
 }
 
-// Transform the given mode into an raw mode (non-canonical) mode.
-fn raw_terminal_attr(termios: &mut Termios) {
-    unsafe { cfmakeraw(termios) }
+fn get_terminal_attr(fd: impl AsFd) -> io::Result<Termios> {
+    let result = rustix::termios::tcgetattr(fd)?;
+    Ok(result)
 }
 
-fn get_terminal_attr(fd: RawFd) -> io::Result<Termios> {
-    unsafe {
-        let mut termios = mem::zeroed();
-        wrap_with_result(tcgetattr(fd, &mut termios))?;
-        Ok(termios)
-    }
-}
-
-fn set_terminal_attr(fd: RawFd, termios: &Termios) -> io::Result<()> {
-    wrap_with_result(unsafe { tcsetattr(fd, TCSANOW, termios) })
-}
-
-fn wrap_with_result(result: i32) -> io::Result<()> {
-    if result == -1 {
-        Err(io::Error::last_os_error())
-    } else {
-        Ok(())
-    }
+fn set_terminal_attr(fd: impl AsFd, termios: &Termios) -> io::Result<()> {
+    rustix::termios::tcsetattr(fd, rustix::termios::OptionalActions::Now, termios)?;
+    Ok(())
 }

--- a/src/tty.rs
+++ b/src/tty.rs
@@ -30,7 +30,7 @@ pub trait IsTty {
 impl<S: AsRawFd> IsTty for S {
     fn is_tty(&self) -> bool {
         let fd = self.as_raw_fd();
-        unsafe { libc::isatty(fd) == 1 }
+        rustix::termios::isatty(unsafe { std::os::unix::io::BorrowedFd::borrow_raw(fd) })
     }
 }
 

--- a/src/tty.rs
+++ b/src/tty.rs
@@ -30,7 +30,7 @@ pub trait IsTty {
 impl<S: AsRawFd> IsTty for S {
     fn is_tty(&self) -> bool {
         let fd = self.as_raw_fd();
-        rustix::termios::isatty(unsafe { std::os::unix::io::BorrowedFd::borrow_raw(fd) })
+        crate::sys::termios::isatty(unsafe { std::os::unix::io::BorrowedFd::borrow_raw(fd) })
     }
 }
 


### PR DESCRIPTION
Closes #847

rustix is a wrapper around either raw Linux system calls or libc, based
on the current platform. The main advantage is that it can make programs
much more efficient, since system calls can be inlined directly into
the functions that call them. I've seen rustix reduce instruction counts
in my programs when I've made the switch in another programs.

In addition, it reduces the amount of unsafe code.
