### PR TITLE
Improve color detection across platforms

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ futures-timer = "3.0"
 async-std = "1.12"
 serde_json = "1.0"
 serial_test = "2.0.0"
+temp-env = "0.3.6"
 
 #
 # Examples


### PR DESCRIPTION
Fixes https://github.com/crossterm-rs/crossterm/issues/882 by improving `style::available_color_count()`:
- Checks ANSI support on Windows.
- Uses the COLORTERM environment variable and falls back to the TERM environment variable.
- Supports "xterm-24bit" and "truecolor" values which return `u16::MAX`.