### PR TITLE
fix: broken build issues

### DIFF
--- a/.github/workflows/crossterm_test.yml
+++ b/.github/workflows/crossterm_test.yml
@@ -66,6 +66,10 @@ jobs:
       if: matrix.os != 'windows-2019'
       run: cargo test --no-default-features -- --nocapture --test-threads 1
       continue-on-error: ${{ matrix.can-fail }}
+    - name: Test no default features with use-dev-tty feature enabled
+      if: matrix.os != 'windows-2019'
+      run: cargo test --no-default-features --features "use-dev-tty events" -- --nocapture --test-threads 1
+      continue-on-error: ${{ matrix.can-fail }}
     - name: Test no default features with windows feature enabled
       if: matrix.os == 'windows-2019'
       run: cargo test --no-default-features --features "windows" -- --nocapture --test-threads 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,18 +28,28 @@ all-features = true
 #
 [features]
 default = ["bracketed-paste", "windows", "events"]
-windows = ["dep:winapi", "dep:crossterm_winapi"] # Disables winapi dependencies from being included into the binary (SHOULD NOT be disabled on windows).
-bracketed-paste = [] # Enables triggering a `Event::Paste` when pasting text into the terminal.
+windows = [
+    "dep:winapi",
+    "dep:crossterm_winapi",
+] # Disables winapi dependencies from being included into the binary (SHOULD NOT be disabled on windows).
+bracketed-paste = [
+] # Enables triggering a `Event::Paste` when pasting text into the terminal.
 event-stream = ["dep:futures-core", "events"] # Enables async events
-use-dev-tty = ["filedescriptor"] # Enables raw file descriptor polling / selecting instead of mio.
-events = ["dep:mio", "dep:signal-hook", "dep:signal-hook-mio"] # Enables reading input/events from the system.
+use-dev-tty = [
+    "filedescriptor",
+] # Enables raw file descriptor polling / selecting instead of mio.
+events = [
+    "dep:mio",
+    "dep:signal-hook",
+    "dep:signal-hook-mio",
+] # Enables reading input/events from the system.
 serde = ["dep:serde", "bitflags/serde"] # Enables 'serde' for various types.
 
 #
 # Shared dependencies
 #
 [dependencies]
-bitflags = {version = "2.3" }
+bitflags = { version = "2.3" }
 parking_lot = "0.12"
 
 # optional deps only added when requested
@@ -65,7 +75,9 @@ libc = "0.2"
 signal-hook = { version = "0.3.17", optional = true }
 filedescriptor = { version = "0.8", optional = true }
 mio = { version = "0.8", features = ["os-poll"], optional = true }
-signal-hook-mio = { version = "0.2.3", features = ["support-v0_8"], optional = true }
+signal-hook-mio = { version = "0.2.3", features = [
+    "support-v0_8",
+], optional = true }
 
 #
 # Dev dependencies (examples, ...)
@@ -107,4 +119,8 @@ required-features = ["events"]
 
 [[example]]
 name = "stderr"
+required-features = ["events"]
+
+[[example]]
+name = "key-display"
 required-features = ["events"]

--- a/src/cursor/sys.rs
+++ b/src/cursor/sys.rs
@@ -4,6 +4,7 @@
 #[cfg(feature = "events")]
 pub use self::unix::position;
 #[cfg(windows)]
+#[cfg(feature = "events")]
 pub use self::windows::position;
 #[cfg(windows)]
 pub(crate) use self::windows::{

--- a/src/event.rs
+++ b/src/event.rs
@@ -910,7 +910,7 @@ impl Display for ModifierKeyCode {
     ///
     /// # Platform-specific Notes
     ///
-    /// On macOS, the control, alt, and super keys is displayed as "Control", "Option", and
+    /// On macOS, the control, alt, and super keys are displayed as "Control", "Option", and
     /// "Command" respectively. See
     /// <https://support.apple.com/guide/applestyleguide/welcome/1.0/web>.
     ///
@@ -920,7 +920,6 @@ impl Display for ModifierKeyCode {
     ///
     /// On other platforms, the super key is referred to as "Super".
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        #[cfg(target_os = "macos")]
         match self {
             ModifierKeyCode::LeftShift => write!(f, "Left Shift"),
             ModifierKeyCode::LeftHyper => write!(f, "Left Hyper"),

--- a/src/event/source/unix/tty.rs
+++ b/src/event/source/unix/tty.rs
@@ -80,7 +80,7 @@ impl UnixInternalEventSource {
 /// only fills the given buffer and does not read beyond that.
 fn read_complete(fd: &FileDesc, buf: &mut [u8]) -> io::Result<usize> {
     loop {
-        match fd.read(buf, buf.len()) {
+        match fd.read(buf) {
             Ok(x) => return Ok(x),
             Err(e) => match e.kind() {
                 io::ErrorKind::WouldBlock => return Ok(0),

--- a/src/style/attributes.rs
+++ b/src/style/attributes.rs
@@ -140,8 +140,11 @@ mod tests {
 
     #[test]
     fn test_attributes_const() {
-      const ATTRIBUTES: Attributes = Attributes::none().with(Attribute::Bold).with(Attribute::Italic).without(Attribute::Bold);
-      assert!(!ATTRIBUTES.has(Attribute::Bold));
-      assert!(ATTRIBUTES.has(Attribute::Italic));
+        const ATTRIBUTES: Attributes = Attributes::none()
+            .with(Attribute::Bold)
+            .with(Attribute::Italic)
+            .without(Attribute::Bold);
+        assert!(!ATTRIBUTES.has(Attribute::Bold));
+        assert!(ATTRIBUTES.has(Attribute::Italic));
     }
 }

--- a/src/style/types/color.rs
+++ b/src/style/types/color.rs
@@ -246,15 +246,11 @@ impl serde::ser::Serialize for Color {
 
         if str.is_empty() {
             match *self {
-                Color::AnsiValue(value) => {
-                    serializer.serialize_str(&format!("ansi_({})", value))
-                }
+                Color::AnsiValue(value) => serializer.serialize_str(&format!("ansi_({})", value)),
                 Color::Rgb { r, g, b } => {
                     serializer.serialize_str(&format!("rgb_({},{},{})", r, g, b))
                 }
-                _ => {
-                    Err(serde::ser::Error::custom("Could not serialize enum type"))
-                }
+                _ => Err(serde::ser::Error::custom("Could not serialize enum type")),
             }
         } else {
             serializer.serialize_str(str)


### PR DESCRIPTION
Several issues were encountered after the merging of various PRs.
This was mostly caused by CI not being run on all of the PRs (I suspect
this was due to the GitHub first time repo contributor setting).

- An incorrect #[cfg] attribute introduced in #862 prevented compilation on unix
- Several formatting errors are fixed
- A for loop that (validly) only inspects the first element changed to if ....next() == Some(...)
- FileDesc.read now does not take a length parameter
- Key display example requires the "events" feature flag
- Adds use-dev-tty to testing matrix (credit gwenn <gtreguier@gmail.com>) in #887 
 
Fixes: https://github.com/crossterm-rs/crossterm/issues/883
Fixes: https://github.com/crossterm-rs/crossterm/issues/883
Supersedes: https://github.com/crossterm-rs/crossterm/issues/887
Supersedes: https://github.com/crossterm-rs/crossterm/issues/884