### PR TITLE
Use rustix instead of libc (additive only approach)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+- Use Rustix by default instead of libc. Libc can be re-enabled if necessary with the libc feature flag.
+- `FileDesc` now requires a lifetime annotation.
+
 # Version 0.27.1
 
 ## Added ⭐

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ all-features = true
 # Features
 #
 [features]
-default = ["bracketed-paste", "windows", "events", "libc"]
+default = ["bracketed-paste", "windows", "events"]
 windows = [
     "dep:winapi",
     "dep:crossterm_winapi",
@@ -71,12 +71,14 @@ crossterm_winapi = { version = "0.9.1", optional = true }
 # UNIX dependencies
 #
 [target.'cfg(unix)'.dependencies]
+# Default to using rustix for UNIX systems, but provide an option to use libc for backwards
+# compatibility.
 libc = { version = "0.2", default-features = false, optional = true }
 rustix = { version = "0.38.34", default-features = false, features = [
     "std",
     "stdio",
     "termios",
-], optional = true }
+] }
 signal-hook = { version = "0.3.17", optional = true }
 filedescriptor = { version = "0.8", optional = true }
 mio = { version = "0.8", features = ["os-poll"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["event", "color", "cli", "input", "terminal"]
 exclude = ["target", "Cargo.lock"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.58.0"
+rust-version = "1.63.0"
 categories = ["command-line-interface", "command-line-utilities"]
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ all-features = true
 # Features
 #
 [features]
-default = ["bracketed-paste", "windows", "events"]
+default = ["bracketed-paste", "windows", "events", "libc"]
 windows = [
     "dep:winapi",
     "dep:crossterm_winapi",
@@ -71,7 +71,12 @@ crossterm_winapi = { version = "0.9.1", optional = true }
 # UNIX dependencies
 #
 [target.'cfg(unix)'.dependencies]
-libc = "0.2"
+libc = { version = "0.2", default-features = false, optional = true }
+rustix = { version = "0.38.34", default-features = false, features = [
+    "std",
+    "stdio",
+    "termios",
+], optional = true }
 signal-hook = { version = "0.3.17", optional = true }
 filedescriptor = { version = "0.8", optional = true }
 mio = { version = "0.8", features = ["os-poll"], optional = true }

--- a/src/event/source/unix/mio.rs
+++ b/src/event/source/unix/mio.rs
@@ -26,7 +26,7 @@ pub(crate) struct UnixInternalEventSource {
     events: Events,
     parser: Parser,
     tty_buffer: [u8; TTY_BUFFER_SIZE],
-    tty_fd: FileDesc,
+    tty_fd: FileDesc<'static>,
     signals: Signals,
     #[cfg(feature = "event-stream")]
     waker: Waker,
@@ -37,7 +37,7 @@ impl UnixInternalEventSource {
         UnixInternalEventSource::from_file_descriptor(tty_fd()?)
     }
 
-    pub(crate) fn from_file_descriptor(input_fd: FileDesc) -> io::Result<Self> {
+    pub(crate) fn from_file_descriptor(input_fd: FileDesc<'static>) -> io::Result<Self> {
         let poll = Poll::new()?;
         let registry = poll.registry();
 

--- a/src/terminal/sys/file_descriptor.rs
+++ b/src/terminal/sys/file_descriptor.rs
@@ -2,7 +2,7 @@ use std::io;
 
 #[cfg(feature = "libc")]
 use libc::size_t;
-#[cfg(feature = "rustix")]
+#[cfg(not(feature = "libc"))]
 use rustix::fd::{AsFd, AsRawFd, BorrowedFd, OwnedFd, RawFd};
 #[cfg(feature = "libc")]
 use std::{
@@ -24,7 +24,7 @@ pub struct FileDesc {
     close_on_drop: bool,
 }
 
-#[cfg(feature = "rustix")]
+#[cfg(not(feature = "libc"))]
 pub enum FileDesc {
     Owned(OwnedFd),
     Static(BorrowedFd<'static>),
@@ -64,7 +64,7 @@ impl FileDesc {
     }
 }
 
-#[cfg(feature = "rustix")]
+#[cfg(not(feature = "libc"))]
 impl FileDesc {
     pub fn read(&self, buffer: &mut [u8]) -> io::Result<usize> {
         let fd = match self {
@@ -103,7 +103,7 @@ impl AsRawFd for FileDesc {
     }
 }
 
-#[cfg(feature = "rustix")]
+#[cfg(not(feature = "libc"))]
 impl AsFd for FileDesc {
     fn as_fd(&self) -> BorrowedFd<'_> {
         match self {
@@ -132,7 +132,7 @@ pub fn tty_fd() -> io::Result<FileDesc> {
     Ok(FileDesc::new(fd, close_on_drop))
 }
 
-#[cfg(feature = "rustix")]
+#[cfg(not(feature = "libc"))]
 /// Creates a file descriptor pointing to the standard input or `/dev/tty`.
 pub fn tty_fd() -> io::Result<FileDesc> {
     use std::fs::File;

--- a/src/terminal/sys/unix.rs
+++ b/src/terminal/sys/unix.rs
@@ -10,7 +10,7 @@ use libc::{
     TIOCGWINSZ,
 };
 use parking_lot::Mutex;
-#[cfg(feature = "rustix")]
+#[cfg(not(feature = "libc"))]
 use rustix::{
     fd::AsFd,
     termios::{Termios, Winsize},
@@ -42,7 +42,7 @@ impl From<winsize> for WindowSize {
         }
     }
 }
-#[cfg(feature = "rustix")]
+#[cfg(not(feature = "libc"))]
 impl From<Winsize> for WindowSize {
     fn from(size: Winsize) -> WindowSize {
         WindowSize {
@@ -80,7 +80,7 @@ pub(crate) fn window_size() -> io::Result<WindowSize> {
     Err(std::io::Error::last_os_error().into())
 }
 
-#[cfg(feature = "rustix")]
+#[cfg(not(feature = "libc"))]
 pub(crate) fn window_size() -> io::Result<WindowSize> {
     let file = File::open("/dev/tty").map(|file| (FileDesc::Owned(file.into())));
     let fd = if let Ok(file) = &file {
@@ -120,7 +120,7 @@ pub(crate) fn enable_raw_mode() -> io::Result<()> {
     Ok(())
 }
 
-#[cfg(feature = "rustix")]
+#[cfg(not(feature = "libc"))]
 pub(crate) fn enable_raw_mode() -> io::Result<()> {
     let mut original_mode = TERMINAL_MODE_PRIOR_RAW_MODE.lock();
     if original_mode.is_some() {
@@ -154,7 +154,7 @@ pub(crate) fn disable_raw_mode() -> io::Result<()> {
     Ok(())
 }
 
-#[cfg(feature = "rustix")]
+#[cfg(not(feature = "libc"))]
 pub(crate) fn disable_raw_mode() -> io::Result<()> {
     let mut original_mode = TERMINAL_MODE_PRIOR_RAW_MODE.lock();
     if let Some(original_mode_ios) = original_mode.as_ref() {
@@ -166,13 +166,13 @@ pub(crate) fn disable_raw_mode() -> io::Result<()> {
     Ok(())
 }
 
-#[cfg(feature = "rustix")]
+#[cfg(not(feature = "libc"))]
 fn get_terminal_attr(fd: impl AsFd) -> io::Result<Termios> {
     let result = rustix::termios::tcgetattr(fd)?;
     Ok(result)
 }
 
-#[cfg(feature = "rustix")]
+#[cfg(not(feature = "libc"))]
 fn set_terminal_attr(fd: impl AsFd, termios: &Termios) -> io::Result<()> {
     rustix::termios::tcsetattr(fd, rustix::termios::OptionalActions::Now, termios)?;
     Ok(())

--- a/src/terminal/sys/unix.rs
+++ b/src/terminal/sys/unix.rs
@@ -4,16 +4,24 @@ use crate::terminal::{
     sys::file_descriptor::{tty_fd, FileDesc},
     WindowSize,
 };
+#[cfg(feature = "libc")]
 use libc::{
     cfmakeraw, ioctl, tcgetattr, tcsetattr, termios as Termios, winsize, STDOUT_FILENO, TCSANOW,
     TIOCGWINSZ,
 };
 use parking_lot::Mutex;
-use std::fs::File;
+#[cfg(feature = "rustix")]
+use rustix::{
+    fd::AsFd,
+    termios::{Termios, Winsize},
+};
 
-use std::os::unix::io::{IntoRawFd, RawFd};
-
-use std::{io, mem, process};
+use std::{fs::File, io, process};
+#[cfg(feature = "libc")]
+use std::{
+    mem,
+    os::unix::io::{IntoRawFd, RawFd},
+};
 
 // Some(Termios) -> we're in the raw mode and this is the previous mode
 // None -> we're not in the raw mode
@@ -23,6 +31,7 @@ pub(crate) fn is_raw_mode_enabled() -> bool {
     TERMINAL_MODE_PRIOR_RAW_MODE.lock().is_some()
 }
 
+#[cfg(feature = "libc")]
 impl From<winsize> for WindowSize {
     fn from(size: winsize) -> WindowSize {
         WindowSize {
@@ -33,8 +42,20 @@ impl From<winsize> for WindowSize {
         }
     }
 }
+#[cfg(feature = "rustix")]
+impl From<Winsize> for WindowSize {
+    fn from(size: Winsize) -> WindowSize {
+        WindowSize {
+            columns: size.ws_col,
+            rows: size.ws_row,
+            width: size.ws_xpixel,
+            height: size.ws_ypixel,
+        }
+    }
+}
 
 #[allow(clippy::useless_conversion)]
+#[cfg(feature = "libc")]
 pub(crate) fn window_size() -> io::Result<WindowSize> {
     // http://rosettacode.org/wiki/Terminal_control/Dimensions#Library:_BSD_libc
     let mut size = winsize {
@@ -59,6 +80,19 @@ pub(crate) fn window_size() -> io::Result<WindowSize> {
     Err(std::io::Error::last_os_error().into())
 }
 
+#[cfg(feature = "rustix")]
+pub(crate) fn window_size() -> io::Result<WindowSize> {
+    let file = File::open("/dev/tty").map(|file| (FileDesc::Owned(file.into())));
+    let fd = if let Ok(file) = &file {
+        file.as_fd()
+    } else {
+        // Fallback to libc::STDOUT_FILENO if /dev/tty is missing
+        rustix::stdio::stdout()
+    };
+    let size = rustix::termios::tcgetwinsize(fd)?;
+    Ok(size.into())
+}
+
 #[allow(clippy::useless_conversion)]
 pub(crate) fn size() -> io::Result<(u16, u16)> {
     if let Ok(window_size) = window_size() {
@@ -68,9 +102,9 @@ pub(crate) fn size() -> io::Result<(u16, u16)> {
     tput_size().ok_or_else(|| std::io::Error::last_os_error().into())
 }
 
+#[cfg(feature = "libc")]
 pub(crate) fn enable_raw_mode() -> io::Result<()> {
     let mut original_mode = TERMINAL_MODE_PRIOR_RAW_MODE.lock();
-
     if original_mode.is_some() {
         return Ok(());
     }
@@ -79,13 +113,27 @@ pub(crate) fn enable_raw_mode() -> io::Result<()> {
     let fd = tty.raw_fd();
     let mut ios = get_terminal_attr(fd)?;
     let original_mode_ios = ios;
-
     raw_terminal_attr(&mut ios);
     set_terminal_attr(fd, &ios)?;
-
     // Keep it last - set the original mode only if we were able to switch to the raw mode
     *original_mode = Some(original_mode_ios);
+    Ok(())
+}
 
+#[cfg(feature = "rustix")]
+pub(crate) fn enable_raw_mode() -> io::Result<()> {
+    let mut original_mode = TERMINAL_MODE_PRIOR_RAW_MODE.lock();
+    if original_mode.is_some() {
+        return Ok(());
+    }
+
+    let tty = tty_fd()?;
+    let mut ios = get_terminal_attr(&tty)?;
+    let original_mode_ios = ios.clone();
+    ios.make_raw();
+    set_terminal_attr(&tty, &ios)?;
+    // Keep it last - set the original mode only if we were able to switch to the raw mode
+    *original_mode = Some(original_mode_ios);
     Ok(())
 }
 
@@ -94,16 +142,39 @@ pub(crate) fn enable_raw_mode() -> io::Result<()> {
 /// More precisely, reset the whole termios mode to what it was before the first call
 /// to [enable_raw_mode]. If you don't mess with termios outside of crossterm, it's
 /// effectively disabling the raw mode and doing nothing else.
+#[cfg(feature = "libc")]
 pub(crate) fn disable_raw_mode() -> io::Result<()> {
     let mut original_mode = TERMINAL_MODE_PRIOR_RAW_MODE.lock();
-
     if let Some(original_mode_ios) = original_mode.as_ref() {
         let tty = tty_fd()?;
         set_terminal_attr(tty.raw_fd(), original_mode_ios)?;
         // Keep it last - remove the original mode only if we were able to switch back
         *original_mode = None;
     }
+    Ok(())
+}
 
+#[cfg(feature = "rustix")]
+pub(crate) fn disable_raw_mode() -> io::Result<()> {
+    let mut original_mode = TERMINAL_MODE_PRIOR_RAW_MODE.lock();
+    if let Some(original_mode_ios) = original_mode.as_ref() {
+        let tty = tty_fd()?;
+        set_terminal_attr(&tty, original_mode_ios)?;
+        // Keep it last - remove the original mode only if we were able to switch back
+        *original_mode = None;
+    }
+    Ok(())
+}
+
+#[cfg(feature = "rustix")]
+fn get_terminal_attr(fd: impl AsFd) -> io::Result<Termios> {
+    let result = rustix::termios::tcgetattr(fd)?;
+    Ok(result)
+}
+
+#[cfg(feature = "rustix")]
+fn set_terminal_attr(fd: impl AsFd, termios: &Termios) -> io::Result<()> {
+    rustix::termios::tcsetattr(fd, rustix::termios::OptionalActions::Now, termios)?;
     Ok(())
 }
 
@@ -214,11 +285,13 @@ fn tput_size() -> Option<(u16, u16)> {
     }
 }
 
+#[cfg(feature = "libc")]
 // Transform the given mode into an raw mode (non-canonical) mode.
 fn raw_terminal_attr(termios: &mut Termios) {
     unsafe { cfmakeraw(termios) }
 }
 
+#[cfg(feature = "libc")]
 fn get_terminal_attr(fd: RawFd) -> io::Result<Termios> {
     unsafe {
         let mut termios = mem::zeroed();
@@ -227,10 +300,12 @@ fn get_terminal_attr(fd: RawFd) -> io::Result<Termios> {
     }
 }
 
+#[cfg(feature = "libc")]
 fn set_terminal_attr(fd: RawFd, termios: &Termios) -> io::Result<()> {
     wrap_with_result(unsafe { tcsetattr(fd, TCSANOW, termios) })
 }
 
+#[cfg(feature = "libc")]
 fn wrap_with_result(result: i32) -> io::Result<()> {
     if result == -1 {
         Err(io::Error::last_os_error())

--- a/src/tty.rs
+++ b/src/tty.rs
@@ -26,11 +26,19 @@ pub trait IsTty {
 
 /// On UNIX, the `isatty()` function returns true if a file
 /// descriptor is a terminal.
-#[cfg(unix)]
+#[cfg(all(unix, feature = "libc"))]
 impl<S: AsRawFd> IsTty for S {
     fn is_tty(&self) -> bool {
         let fd = self.as_raw_fd();
         unsafe { libc::isatty(fd) == 1 }
+    }
+}
+
+#[cfg(all(unix, feature = "rustix"))]
+impl<S: AsRawFd> IsTty for S {
+    fn is_tty(&self) -> bool {
+        let fd = self.as_raw_fd();
+        rustix::termios::isatty(unsafe { std::os::unix::io::BorrowedFd::borrow_raw(fd) })
     }
 }
 

--- a/src/tty.rs
+++ b/src/tty.rs
@@ -34,7 +34,7 @@ impl<S: AsRawFd> IsTty for S {
     }
 }
 
-#[cfg(all(unix, feature = "rustix"))]
+#[cfg(all(unix, not(feature = "libc")))]
 impl<S: AsRawFd> IsTty for S {
     fn is_tty(&self) -> bool {
         let fd = self.as_raw_fd();


### PR DESCRIPTION
- **use rustix instead of libc**
- **make rustix the default feature**

This is an purely additive alternative approach to #878. Instead of modifying the code paths that were hitting libc, this version instead adds feature gated additions (one path for not(libc), one for libc).

Closes: #847 
