### PR TITLE
fix: extra command in event-read example

### DIFF
--- a/examples/event-read.rs
+++ b/examples/event-read.rs
@@ -104,7 +104,6 @@ fn main() -> io::Result<()> {
     execute!(
         stdout,
         DisableBracketedPaste,
-        PopKeyboardEnhancementFlags,
         DisableFocusChange,
         DisableMouseCapture
     )?;


### PR DESCRIPTION
Resolves #842

`PopKeyboardEnhancementFlags` is already called here with the proper check:https://github.com/crossterm-rs/crossterm/blob/fce58c879a748f3159216f68833100aa16141ab0/examples/event-read.rs#L100-L102 so we don't need to call it again.