### PR TITLE
🐛 Fix: format error [E0277]

### DIFF
--- a/examples/key-display.rs
+++ b/examples/key-display.rs
@@ -35,9 +35,9 @@ fn print_events() -> io::Result<()> {
             Event::Key(event) if event.kind == KeyEventKind::Press => {
                 print!("Key pressed: ");
                 if event.modifiers != KeyModifiers::NONE {
-                    print!("{}+", event.modifiers);
+                    print!("{:?}+", event.modifiers);
                 }
-                println!("{}\r", event.code);
+                println!("{:?}\r", event.code);
                 if event.code == KeyCode::Esc {
                     break;
                 }


### PR DESCRIPTION
KeyCode and KeyModifiers didn't implement std::fmt::Display, this will produce errors when compiling.

Compiler outputs as following.
```
error[E0277]: `KeyModifiers` doesn't implement `std::fmt::Display`
  --> src/main.rs:38:35
   |
38 |                     print!("{}+", event.modifiers);
   |                                   ^^^^^^^^^^^^^^^ `KeyModifiers` cannot be formatted with the default formatter
   |
   = help: the trait `std::fmt::Display` is not implemented for `KeyModifiers`
   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
   = note: this error originates in the macro `$crate::format_args` which comes from the expansion of the macro `print` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0277]: `KeyCode` doesn't implement `std::fmt::Display`
  --> src/main.rs:40:34
   |
40 |                 println!("{}\r", event.code);
   |                                  ^^^^^^^^^^ `KeyCode` cannot be formatted with the default formatter
   |
   = help: the trait `std::fmt::Display` is not implemented for `KeyCode`
   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)

For more information about this error, try `rustc --explain E0277`.
```