### PR TITLE
Require rustix/process when use-dev-tty is enabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ bracketed-paste = [
 event-stream = ["dep:futures-core", "events"] # Enables async events
 use-dev-tty = [
     "filedescriptor",
+    "rustix/process",
 ] # Enables raw file descriptor polling / selecting instead of mio.
 events = [
     "dep:mio",


### PR DESCRIPTION
Fixes #905 