### PR TITLE
feat(cursor): Derive multiple traits for "SetCursorStyle"

### DIFF
--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -370,7 +370,7 @@ impl Command for DisableBlinking {
 /// # Note
 ///
 /// - Commands must be executed/queued for execution otherwise they do nothing.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SetCursorStyle {
     /// Default cursor shape configured by the user.
     DefaultUserShape,

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -433,7 +433,7 @@ mod tests {
 
     use super::{
         sys::position, MoveDown, MoveLeft, MoveRight, MoveTo, MoveUp, RestorePosition,
-        SavePosition, SetCursorStyle,
+        SavePosition,
     };
 
     // Test is disabled, because it's failing on Travis

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -432,8 +432,7 @@ mod tests {
     use crate::execute;
 
     use super::{
-        sys::position, MoveDown, MoveLeft, MoveRight, MoveTo, MoveUp, RestorePosition,
-        SavePosition,
+        sys::position, MoveDown, MoveLeft, MoveRight, MoveTo, MoveUp, RestorePosition, SavePosition,
     };
 
     // Test is disabled, because it's failing on Travis

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -370,7 +370,7 @@ impl Command for DisableBlinking {
 /// # Note
 ///
 /// - Commands must be executed/queued for execution otherwise they do nothing.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum SetCursorStyle {
     /// Default cursor shape configured by the user.
     DefaultUserShape,
@@ -432,7 +432,8 @@ mod tests {
     use crate::execute;
 
     use super::{
-        sys::position, MoveDown, MoveLeft, MoveRight, MoveTo, MoveUp, RestorePosition, SavePosition,
+        sys::position, MoveDown, MoveLeft, MoveRight, MoveTo, MoveUp, RestorePosition,
+        SavePosition, SetCursorStyle,
     };
 
     // Test is disabled, because it's failing on Travis
@@ -500,5 +501,19 @@ mod tests {
 
         assert_eq!(x, saved_x);
         assert_eq!(y, saved_y);
+    }
+
+    #[test]
+    fn test_set_cursor_style() {
+        assert_eq!(
+            SetCursorStyle::DefaultUserShape,
+            SetCursorStyle::DefaultUserShape
+        );
+        assert_eq!(SetCursorStyle::BlinkingBlock, SetCursorStyle::BlinkingBlock,);
+        assert_ne!(
+            SetCursorStyle::BlinkingBlock,
+            SetCursorStyle::BlinkingUnderScore,
+        );
+        assert_eq!(format!("{:?}", SetCursorStyle::SteadyBar), "SteadyBar");
     }
 }

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -504,19 +504,4 @@ mod tests {
         assert_eq!(y, saved_y);
     }
 
-    #[test]
-    fn test_set_cursor_style() {
-        assert!(SetCursorStyle::DefaultUserShape == SetCursorStyle::DefaultUserShape);
-        assert!(SetCursorStyle::BlinkingBlock != SetCursorStyle::BlinkingUnderScore);
-        assert_eq!(SetCursorStyle::BlinkingBlock, SetCursorStyle::BlinkingBlock);
-        assert_eq!(format!("{:?}", SetCursorStyle::SteadyBar), "SteadyBar");
-        let s1 = SetCursorStyle::DefaultUserShape;
-        let s2 = s1;
-        let s3 = s1.clone();
-        assert!(s2 == s1);
-        assert!(s3 == s1);
-        let mut hasher = DefaultHasher::new();
-        assert!(s1.hash(&mut hasher) == s2.hash(&mut hasher));
-        assert!(s1.hash(&mut hasher) == s3.hash(&mut hasher));
-    }
 }

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -370,7 +370,7 @@ impl Command for DisableBlinking {
 /// # Note
 ///
 /// - Commands must be executed/queued for execution otherwise they do nothing.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Hash)]
 pub enum SetCursorStyle {
     /// Default cursor shape configured by the user.
     DefaultUserShape,
@@ -427,6 +427,7 @@ impl_display!(for SetCursorStyle);
 #[cfg(test)]
 #[cfg(feature = "events")]
 mod tests {
+    use std::hash::{DefaultHasher, Hash};
     use std::io::{self, stdout};
 
     use crate::execute;
@@ -509,5 +510,22 @@ mod tests {
         assert!(SetCursorStyle::BlinkingBlock != SetCursorStyle::BlinkingUnderScore);
         assert_eq!(SetCursorStyle::BlinkingBlock, SetCursorStyle::BlinkingBlock);
         assert_eq!(format!("{:?}", SetCursorStyle::SteadyBar), "SteadyBar");
+        let s1 = SetCursorStyle::DefaultUserShape;
+        let s2 = s1;
+        let s3 = s1.clone();
+        assert!(s2 == s1);
+        assert!(s3 == s1);
+        let mut hasher = DefaultHasher::new();
+        let h1 = &s1;
+        let h2 = &s2;
+        let h3 = &s3;
+        assert!(h1.hash(&mut hasher) == h2.hash(&mut hasher));
+        assert!(h1.hash(&mut hasher) == h3.hash(&mut hasher));
+        assert!(SetCursorStyle::DefaultUserShape < SetCursorStyle::BlinkingBlock);
+        assert!(SetCursorStyle::BlinkingBlock < SetCursorStyle::SteadyBlock);
+        assert!(SetCursorStyle::SteadyBlock < SetCursorStyle::BlinkingUnderScore);
+        assert!(SetCursorStyle::BlinkingUnderScore < SetCursorStyle::SteadyUnderScore);
+        assert!(SetCursorStyle::SteadyUnderScore < SetCursorStyle::BlinkingBar);
+        assert!(SetCursorStyle::BlinkingBar < SetCursorStyle::SteadyBar);
     }
 }

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -505,15 +505,9 @@ mod tests {
 
     #[test]
     fn test_set_cursor_style() {
-        assert_eq!(
-            SetCursorStyle::DefaultUserShape,
-            SetCursorStyle::DefaultUserShape
-        );
+        assert!(SetCursorStyle::DefaultUserShape == SetCursorStyle::DefaultUserShape);
+        assert!(SetCursorStyle::BlinkingBlock != SetCursorStyle::BlinkingUnderScore);
         assert_eq!(SetCursorStyle::BlinkingBlock, SetCursorStyle::BlinkingBlock);
-        assert_ne!(
-            SetCursorStyle::BlinkingBlock,
-            SetCursorStyle::BlinkingUnderScore,
-        );
         assert_eq!(format!("{:?}", SetCursorStyle::SteadyBar), "SteadyBar");
     }
 }

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -509,7 +509,7 @@ mod tests {
             SetCursorStyle::DefaultUserShape,
             SetCursorStyle::DefaultUserShape
         );
-        assert_eq!(SetCursorStyle::BlinkingBlock, SetCursorStyle::BlinkingBlock,);
+        assert_eq!(SetCursorStyle::BlinkingBlock, SetCursorStyle::BlinkingBlock);
         assert_ne!(
             SetCursorStyle::BlinkingBlock,
             SetCursorStyle::BlinkingUnderScore,

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -370,7 +370,7 @@ impl Command for DisableBlinking {
 /// # Note
 ///
 /// - Commands must be executed/queued for execution otherwise they do nothing.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum SetCursorStyle {
     /// Default cursor shape configured by the user.
     DefaultUserShape,
@@ -516,16 +516,7 @@ mod tests {
         assert!(s2 == s1);
         assert!(s3 == s1);
         let mut hasher = DefaultHasher::new();
-        let h1 = &s1;
-        let h2 = &s2;
-        let h3 = &s3;
-        assert!(h1.hash(&mut hasher) == h2.hash(&mut hasher));
-        assert!(h1.hash(&mut hasher) == h3.hash(&mut hasher));
-        assert!(SetCursorStyle::DefaultUserShape < SetCursorStyle::BlinkingBlock);
-        assert!(SetCursorStyle::BlinkingBlock < SetCursorStyle::SteadyBlock);
-        assert!(SetCursorStyle::SteadyBlock < SetCursorStyle::BlinkingUnderScore);
-        assert!(SetCursorStyle::BlinkingUnderScore < SetCursorStyle::SteadyUnderScore);
-        assert!(SetCursorStyle::SteadyUnderScore < SetCursorStyle::BlinkingBar);
-        assert!(SetCursorStyle::BlinkingBar < SetCursorStyle::SteadyBar);
+        assert!(s1.hash(&mut hasher) == s2.hash(&mut hasher));
+        assert!(s1.hash(&mut hasher) == s3.hash(&mut hasher));
     }
 }

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -427,7 +427,6 @@ impl_display!(for SetCursorStyle);
 #[cfg(test)]
 #[cfg(feature = "events")]
 mod tests {
-    use std::hash::{DefaultHasher, Hash};
     use std::io::{self, stdout};
 
     use crate::execute;
@@ -503,5 +502,4 @@ mod tests {
         assert_eq!(x, saved_x);
         assert_eq!(y, saved_y);
     }
-
 }


### PR DESCRIPTION
This PR derives multiple useful traits for `SetCursorStyle` enum:

I checked other enums in `crossterm`, and seems they all have these traits. So I think it's ok to also add to `SetCursorStyle`.

It also adds 1 unit test to make sure they're working.