### PR TITLE
Only for UNIX OS, modify it to enable `O_NONBLOCK` and use event::read().

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crossterm"
-version = "0.28.1"
+version = "0.28.2"
 authors = ["T. Post"]
 description = "A crossplatform terminal library for manipulating terminals."
 repository = "https://github.com/crossterm-rs/crossterm"


### PR DESCRIPTION
Related issue is #854.

Primarily observed during mouse operations on macOS, it seems that if `O_NONBLOCK` is not enabled during `event::read()`, the buffer cannot be read all at once.

However, keeping `O_NONBLOCK` enabled causes subsequent `read()` operations to malfunction, resulting in the program's termination. Therefore, I added a process that enables `O_NONBLOCK` at the start of `read()`, and disables it again after the reading is complete.