### PR TITLE
docs: cleanup warnings

### DIFF
--- a/src/cursor/sys/unix.rs
+++ b/src/cursor/sys/unix.rs
@@ -13,7 +13,7 @@ use crate::{
 /// The top left cell is represented as `(0, 0)`.
 ///
 /// On unix systems, this function will block and possibly time out while
-/// [`crossterm::event::read`](crate::event::read) or [`crossterm::event::poll`](crate::event::poll) are being called.
+/// [`crossterm::event::read`](crate::event::read()) or [`crossterm::event::poll`](crate::event::poll) are being called.
 pub fn position() -> io::Result<(u16, u16)> {
     if is_raw_mode_enabled() {
         read_position_raw()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -251,10 +251,7 @@ mod command;
 pub(crate) mod macros;
 
 #[cfg(all(windows, not(feature = "windows")))]
-compile_error!("Compiling on Windows with \"windows\" feature disabled. Feature \"windows\" should only be disabled when project will never be compiled on Windows.");
-
-#[cfg(all(winapi, not(feature = "winapi")))]
-compile_error!("Compiling on Windows with \"winapi\" feature disabled. Feature \"winapi\" should only be disabled when project will never be compiled on Windows.");
-
-#[cfg(all(crossterm_winapi, not(feature = "crossterm_winapi")))]
-compile_error!("Compiling on Windows with \"crossterm_winapi\" feature disabled. Feature \"crossterm_winapi\" should only be disabled when project will never be compiled on Windows.");
+compile_error!(
+    "Compiling on Windows with \"windows\" feature disabled. \
+Feature \"windows\" should only be disabled when project will never be compiled on Windows."
+);

--- a/src/style.rs
+++ b/src/style.rs
@@ -184,7 +184,7 @@ pub fn available_color_count() -> u16 {
 ///
 /// # Notes
 ///
-/// crossterm supports NO_COLOR (https://no-color.org/) to disabled colored output.
+/// crossterm supports NO_COLOR (<https://no-color.org/>) to disabled colored output.
 ///
 /// This API allows applications to override that behavior and force colorized output
 /// even if NO_COLOR is set.

--- a/src/style/types/colored.rs
+++ b/src/style/types/colored.rs
@@ -71,7 +71,7 @@ impl Colored {
     }
 
     /// Checks whether ansi color sequences are disabled by setting of NO_COLOR
-    /// in environment as per https://no-color.org/
+    /// in environment as per <https://no-color.org/>
     pub fn ansi_color_disabled() -> bool {
         !std::env::var("NO_COLOR")
             .unwrap_or("".to_string())

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -148,7 +148,7 @@ pub struct WindowSize {
 /// Returns the terminal size `[WindowSize]`.
 ///
 /// The width and height in pixels may not be reliably implemented or default to 0.
-/// For unix, https://man7.org/linux/man-pages/man4/tty_ioctl.4.html documents them as "unused".
+/// For unix, <https://man7.org/linux/man-pages/man4/tty_ioctl.4.html> documents them as "unused".
 /// For windows it is not implemented.
 pub fn window_size() -> io::Result<WindowSize> {
     sys::window_size()

--- a/src/terminal/sys/unix.rs
+++ b/src/terminal/sys/unix.rs
@@ -181,7 +181,7 @@ fn set_terminal_attr(fd: impl AsFd, termios: &Termios) -> io::Result<()> {
 /// Queries the terminal's support for progressive keyboard enhancement.
 ///
 /// On unix systems, this function will block and possibly time out while
-/// [`crossterm::event::read`](crate::event::read) or [`crossterm::event::poll`](crate::event::poll) are being called.
+/// [`event::read`](crate::event::read()) or [`event::poll`](crate::event::poll) are being called.
 #[cfg(feature = "events")]
 pub fn supports_keyboard_enhancement() -> io::Result<bool> {
     if is_raw_mode_enabled() {


### PR DESCRIPTION
```
warning: unexpected `cfg` condition name: `winapi`
   --> src/lib.rs:256:11
    |
256 | #[cfg(all(winapi, not(feature = "winapi")))]
    |           ^^^^^^
    |
    = help: expected names are: `clippy`, `debug_assertions`, `doc`, `docsrs`, `doctest`, `feature`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `rustfmt`, `sanitize`, `sanitizer_cfi_generalize_pointers`, `sanitizer_cfi_normalize_integers`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `ub_checks`, `unix`, and `windows`
    = help: consider using a Cargo feature instead
    = help: or consider adding in `Cargo.toml` the `check-cfg` lint config for the lint:
             [lints.rust]
             unexpected_cfgs = { level = "warn", check-cfg = ['cfg(winapi)'] }
    = help: or consider adding `println!("cargo::rustc-check-cfg=cfg(winapi)");` to the top of the `build.rs`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
    = note: `#[warn(unexpected_cfgs)]` on by default

warning: unexpected `cfg` condition value: `winapi`
   --> src/lib.rs:256:23
    |
256 | #[cfg(all(winapi, not(feature = "winapi")))]
    |                       ^^^^^^^^^^^^^^^^^^
    |
    = note: expected values for `feature` are: `bracketed-paste`, `default`, `event-stream`, `events`, `filedescriptor`, `libc`, `serde`, `use-dev-tty`, and `windows`
    = help: consider adding `winapi` as a feature in `Cargo.toml`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration

warning: unexpected `cfg` condition name: `crossterm_winapi`
   --> src/lib.rs:259:11
    |
259 | #[cfg(all(crossterm_winapi, not(feature = "crossterm_winapi")))]
    |           ^^^^^^^^^^^^^^^^
    |
    = help: consider using a Cargo feature instead
    = help: or consider adding in `Cargo.toml` the `check-cfg` lint config for the lint:
             [lints.rust]
             unexpected_cfgs = { level = "warn", check-cfg = ['cfg(crossterm_winapi)'] }
    = help: or consider adding `println!("cargo::rustc-check-cfg=cfg(crossterm_winapi)");` to the top of the `build.rs`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration

warning: unexpected `cfg` condition value: `crossterm_winapi`
   --> src/lib.rs:259:33
    |
259 | #[cfg(all(crossterm_winapi, not(feature = "crossterm_winapi")))]
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: expected values for `feature` are: `bracketed-paste`, `default`, `event-stream`, `events`, `filedescriptor`, `libc`, `serde`, `use-dev-tty`, and `windows`
    = help: consider adding `crossterm_winapi` as a feature in `Cargo.toml`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration

warning: `crate::event::read` is both a function and a module
  --> src/cursor/sys/unix.rs:16:32
   |
16 | /// [`crossterm::event::read`](crate::event::read) or [`crossterm::event::poll`](crate::event::poll) are being...
   |                                ^^^^^^^^^^^^^^^^^^ ambiguous link
   |
   = note: `#[warn(rustdoc::broken_intra_doc_links)]` on by default
help: to link to the function, add parentheses
   |
16 | /// [`crossterm::event::read`](crate::event::read()) or [`crossterm::event::poll`](crate::event::poll) are being called.
   |                                                  ++
help: to link to the module, prefix with `mod@`
   |
16 | /// [`crossterm::event::read`](mod@crate::event::read) or [`crossterm::event::poll`](crate::event::poll) are being called.
   |                                ++++

warning: `crate::event::read` is both a function and a module
   --> src/terminal/sys/unix.rs:184:32
    |
184 | /// [`crossterm::event::read`](crate::event::read) or [`crossterm::event::poll`](crate::event::poll) are bein...
    |                                ^^^^^^^^^^^^^^^^^^ ambiguous link
    |
help: to link to the function, add parentheses
    |
184 | /// [`crossterm::event::read`](crate::event::read()) or [`crossterm::event::poll`](crate::event::poll) are being called.
    |                                                  ++
help: to link to the module, prefix with `mod@`
    |
184 | /// [`crossterm::event::read`](mod@crate::event::read) or [`crossterm::event::poll`](crate::event::poll) are being called.
    |                                ++++

warning: this URL is not a hyperlink
  --> src/style/types/colored.rs:74:31
   |
74 |     /// in environment as per https://no-color.org/
   |                               ^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://no-color.org/>`
   |
   = note: bare URLs are not automatically turned into clickable links
   = note: `#[warn(rustdoc::bare_urls)]` on by default

warning: this URL is not a hyperlink
   --> src/style.rs:187:34
    |
187 | /// crossterm supports NO_COLOR (https://no-color.org/) to disabled colored output.
    |                                  ^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://no-color.org/>`
    |
    = note: bare URLs are not automatically turned into clickable links

warning: this URL is not a hyperlink
   --> src/terminal.rs:151:15
    |
151 | /// For unix, https://man7.org/linux/man-pages/man4/tty_ioctl.4.html documents them as "unused".
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://man7.org/linux/man-pages/man4/tty_ioctl.4.html>`
    |
    = note: bare URLs are not automatically turned into clickable links

warning: `crossterm` (lib doc) generated 9 warnings (run `cargo fix --lib -p crossterm` to apply 3 suggestions)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.08s
   Generated /Users/joshka/local/crossterm/target/doc/crossterm/index.html
```