### PR TITLE
reduce temporary allocations in Color serde impl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ events = [
     "dep:signal-hook",
     "dep:signal-hook-mio",
 ] # Enables reading input/events from the system.
-serde = ["dep:serde", "bitflags/serde"] # Enables 'serde' for various types.
+serde = ["dep:serde", "dep:arrayvec", "bitflags/serde"] # Enables 'serde' for various types.
 
 #
 # Shared dependencies
@@ -54,6 +54,7 @@ bitflags = { version = "2.3" }
 parking_lot = "0.12"
 
 # optional deps only added when requested
+arrayvec = { version = "0.7.6", optional = true }
 futures-core = { version = "0.3", optional = true, default-features = false }
 serde = { version = "1.0", features = ["derive"], optional = true }
 


### PR DESCRIPTION
hello. i have made some small changes in the impl of Serialize and Deserialize for `crossterm::style::Color` which reduces the number of temporary allocations created. To achieve this, I have:

- replaced calls to `str::replace` with other suitable methods such as `str::strip_{suffix|prefix}` in the deserialize impl
- replaced a collected-into vec with manually polling an iterator 4 times and applying pattern matching in the deserialize impl
- used a stack-based string for formatting ansi and rgb strings instead of the string-based `format!` macro

For ease of implementation, I have brought in the `arrayvec` dependency, dependent on the `serde` crossterm feature. This enables using the `write!` macro on an `arrayvec::ArrayString` rather than fiddling with an array on the stack and having to uphold utf8 invariants manually. The length of the stack-based string is based on the longest possible formatted color, which is `"rgb_(255,255,255)"`, at length 17.

The deserialize tests as written are all still passing, and a manual check of the serialize impls confirms that colors `Color::Rgb{ r: 255, g: 255, b: 255 }`, `Color::Ansi(1)`, and `Color::Red` still serialize as expected (debug printing shown): 
```
Ok("\"rgb_(255,255,255)\"")
Ok("\"ansi_(1)\"")
Ok("\"red\"")
```