### PR TITLE
fix: Update `rustix` to fix the `enable_raw_mode()` error on WSL/Android

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ crossterm_winapi = { version = "0.9.1", optional = true }
 # Default to using rustix for UNIX systems, but provide an option to use libc for backwards
 # compatibility.
 libc = { version = "0.2", default-features = false, optional = true }
-rustix = { version = "0.38.34", default-features = false, features = [
+rustix = { version = "0.38.36", default-features = false, features = [
     "std",
     "stdio",
     "termios",


### PR DESCRIPTION
Fixes https://github.com/crossterm-rs/crossterm/issues/912

Related upstream PR: https://github.com/bytecodealliance/rustix/pull/1147

---

Should we limit `rustix` to just the mirror version, similar to what `libc` does, so that upstream fixes will automatically apply in the future?

https://github.com/crossterm-rs/crossterm/blob/b056370038416584746fd59f7576ecd218b29f8d/Cargo.toml#L77

Also if possible, could we release a patch version of `crossterm` that includes this fix?