### PR TITLE
Docs: Mentions raw OS-Thread outside an async runtime caused by EventStream

### DIFF
--- a/src/event/stream.rs
+++ b/src/event/stream.rs
@@ -29,6 +29,17 @@ use crate::event::{
 ///
 /// Check the [examples](https://github.com/crossterm-rs/crossterm/tree/master/examples) folder to see how to use
 /// it (`event-stream-*`).
+///
+/// ## Caveats
+///
+/// On creating this future, a plain OS-thread is spawned. This thread is not scheduled
+/// under the control of async runtime. This thread only shutdowns when this future is dropped !
+///
+/// This implementation will never yield an end for a stream aka a Ready(None).
+///
+/// User concerned about that overhead caused by the OS thread outside an async runtime,
+/// are advised to implement their own stream implementation
+/// in respect to their used async runtime.
 #[derive(Debug)]
 pub struct EventStream {
     poll_internal_waker: Waker,


### PR DESCRIPTION
## Reason for this PR

This pull request is motivated by the discussion of the following [issue](https://github.com/crossterm-rs/crossterm/issues/608)

The current implementation of the stream "EventStream" is not ideal for a future. I as a user find the current behavior
of the implementation atypical. Futures should not spawn threads outside an async runtime. This fact should be it least documented for now. 

For example, Tokio's documentation mentions when an API uses a dedicated OS-Thread.  

