### PR TITLE
Improve detection for kitty protocol

### DIFF
--- a/src/terminal/sys/unix.rs
+++ b/src/terminal/sys/unix.rs
@@ -216,13 +216,16 @@ fn read_supports_keyboard_enhancement_raw() -> io::Result<bool> {
     // See <https://sw.kovidgoyal.net/kitty/keyboard-protocol/#detection-of-support-for-this-protocol>
 
     // ESC [ ? u        Query progressive keyboard enhancement flags (kitty protocol).
-    // ESC [ c          Query primary device attributes.
-    const QUERY: &[u8] = b"\x1B[?u\x1B[c";
+    // ESC [ 0 c          Query primary device attributes.
+    const QUERY: &[u8] = b"\x1B[?u\x1B[0c";
 
-    let result = File::open("/dev/tty").and_then(|mut file| {
-        file.write_all(QUERY)?;
-        file.flush()
-    });
+    let result = File::options()
+        .write(true)
+        .open("/dev/tty")
+        .and_then(|mut file| {
+            file.write_all(QUERY)?;
+            file.flush()
+        });
     if result.is_err() {
         let mut stdout = io::stdout();
         stdout.write_all(QUERY)?;


### PR DESCRIPTION
- Change DA1 from `\x1B[c` to `\x1B[0c` for [wider support](https://terminalguide.namepad.de/seq/csi_sc/).
- Open `/dev/tty` for writing rather than reading when writing query. 
  
  