### PR TITLE
Fix panic on 0 size terminal on windows

### DIFF
--- a/src/event/source/windows.rs
+++ b/src/event/source/windows.rs
@@ -66,8 +66,8 @@ impl EventSource for WindowsEventSource {
                         InputRecord::WindowBufferSizeEvent(record) => {
                             // windows starts counting at 0, unix at 1, add one to replicate unix behaviour.
                             Some(Event::Resize(
-                                record.size.x as u16 + 1,
-                                record.size.y as u16 + 1,
+                                (record.size.x as i32 + 1) as u16,
+                                (record.size.y as i32 + 1) as u16,
                             ))
                         }
                         InputRecord::FocusEvent(record) => {


### PR DESCRIPTION
Found bug on windows working with ratatui, with everything default, no drawing, just waiting for event.

When BOTH of terminal width & height are changed to 0 (like on image)  
![image](https://github.com/user-attachments/assets/96c8890b-1185-44ea-99f0-4f24050723a6)
there seems to be `record.size.y == -1`, because `record.size.y as u16 + 1` panics with 
```
thread 'main' panicked at C:\...\crossterm-0.28.1\src\event\source\windows.rs:70:33:
attempt to add with overflow
```

```rs
-1i16 as u16 == u16::MAX
u16::MAX + 1 // panics
```
used `as i32` for -1 to become 0 (represents size of terminal better than 65535) and i16::MAX (32767) to become 32768