### PR TITLE
Remove windows feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/lib.rs"
 all-features = true
 
 [features]
-default = ["bracketed-paste", "events", "windows"]
+default = ["bracketed-paste", "events"]
 
 #! ### Default features
 ## Enables triggering [`Event::Paste`](event::Event::Paste) when pasting text into the terminal.
@@ -29,9 +29,6 @@ bracketed-paste = []
 
 ## Enables reading input/events from the system using the [`event`] module.
 events = ["dep:mio", "dep:signal-hook", "dep:signal-hook-mio"]
-
-## Enables windows specific crates.
-windows = ["dep:winapi", "dep:crossterm_winapi"]
 
 #! ### Optional Features
 
@@ -53,8 +50,8 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 
 # Windows dependencies
 [target.'cfg(windows)'.dependencies]
-crossterm_winapi = { version = "0.9.1", optional = true }
-winapi = { version = "0.3.9", optional = true, features = ["winuser", "winerror"] }
+crossterm_winapi = { version = "0.9.1" }
+winapi = { version = "0.3.9", features = ["winuser", "winerror"] }
 
 # UNIX dependencies
 [target.'cfg(unix)'.dependencies]


### PR DESCRIPTION
In #766 / #767, a windows feature flag was added to solve an issue with
the way that Yocto package generation was working. This is not actually
a problem with Crossterm, but with the Yocto package generation tooling
which adds all the dependencies for all features, even if they are not
relevant to the target platform. This is a bug in the Yocto / meta-rust
/ bitbake tooling and not in Crossterm. For more information, see
<https://github.com/meta-rust/cargo-bitbake/issues/58>.

The fix for this on the Yocto side is to remove dependencies that are
conditional on windows. This commit removes the windows feature flag as
it's not needed.

This is a breaking change for any apps which were specifically using
the windows feature flag. If you were using this feature flag, you will
need to update your Cargo.toml to remove it. The necessary dependencies
are still included in the Cargo.toml file, so you should not need to
make any other changes.
