### PR TITLE
Fix event-read-char-line example double read error & auto enter

### DIFF
--- a/examples/event-read-char-line.rs
+++ b/examples/event-read-char-line.rs
@@ -5,12 +5,13 @@
 
 use std::io;
 
-use crossterm::event::{self, Event, KeyCode, KeyEvent};
+use crossterm::{event::{self, Event, KeyCode, KeyEvent, KeyEventKind}, terminal};
 
 pub fn read_char() -> io::Result<char> {
     loop {
         if let Event::Key(KeyEvent {
             code: KeyCode::Char(c),
+            kind: KeyEventKind::Press,
             ..
         }) = event::read()?
         {
@@ -21,24 +22,36 @@ pub fn read_char() -> io::Result<char> {
 
 pub fn read_line() -> io::Result<String> {
     let mut line = String::new();
-    while let Event::Key(KeyEvent { code, .. }) = event::read()? {
-        match code {
-            KeyCode::Enter => {
-                break;
+    loop {
+        if let Event::Key(KeyEvent{
+            code,
+            kind: KeyEventKind::Press,
+            ..
+        }) = event::read()? {
+            match code {
+                KeyCode::Enter => {
+                    break;
+                }
+                KeyCode::Char(c) => {
+                    line.push(c);
+                }
+                _ => {}
             }
-            KeyCode::Char(c) => {
-                line.push(c);
-            }
-            _ => {}
         }
     }
 
     Ok(line)
 }
 
-fn main() {
-    println!("read line:");
-    println!("{:?}", read_line());
-    println!("read char:");
-    println!("{:?}", read_char());
+fn main() -> io::Result<()> {
+    terminal::enable_raw_mode()?;
+
+    println!("read line:\r");
+    println!("{:?}\r", read_line());
+    println!("read char:\r");
+    println!("{:?}\r", read_char());
+    println!("read char again:\r");
+    println!("{:?}\r", read_char());
+
+    terminal::disable_raw_mode()
 }


### PR DESCRIPTION
I tried following the example in `event-read-char-line` to read keyboard character event without having to press enter. I met some problems when I tried this example.   

The first problem is double key input in Windows. I tracked issue #772 and it turns out `kind: KeyEventKind::Press` is not added when reading event in this example.  

The second problem is with `read_line()` function. It seems that it captures the pressed `Enter` command when I run `cargo run --example event-read-char-line`.   

The third problem is, I have to press Enter for `read_char()` to get my keyboard input in WSL. 

I played with this example for some time and compared with other examples. I made some modifications and they should fix these problems. For `read_line()`, I don't know exactly why the original `while` doesn't work but replacing it with `loop` does solve the second problem.
