### PR TITLE
fix: build failure with event-stream, rustix, and use-dev-tty

### DIFF
--- a/.github/workflows/crossterm_test.yml
+++ b/.github/workflows/crossterm_test.yml
@@ -68,7 +68,7 @@ jobs:
       continue-on-error: ${{ matrix.can-fail }}
     - name: Test no default features with use-dev-tty feature enabled
       if: matrix.os != 'windows-2019'
-      run: cargo test --no-default-features --features "use-dev-tty events bracketed-paste" -- --nocapture --test-threads 1
+      run: cargo test --no-default-features --features "use-dev-tty events event-stream bracketed-paste" -- --nocapture --test-threads 1
       continue-on-error: ${{ matrix.can-fail }}
     - name: Test no default features with windows feature enabled
       if: matrix.os == 'windows-2019'

--- a/src/event/source/unix/tty.rs
+++ b/src/event/source/unix/tty.rs
@@ -185,7 +185,10 @@ impl EventSource for UnixInternalEventSource {
 
             #[cfg(feature = "event-stream")]
             if fds[2].revents & POLLIN != 0 {
+                #[cfg(feature = "libc")]
                 let fd = FileDesc::new(self.wake_pipe.receiver.as_raw_fd(), false);
+                #[cfg(not(feature = "libc"))]
+                let fd = FileDesc::Borrowed(self.wake_pipe.receiver.as_fd());
                 // drain the pipe
                 while read_complete(&fd, &mut [0; 1024])? != 0 {}
 


### PR DESCRIPTION
Resolves #935

When the `event-stream`, `rustix`, and `use-dev-tty` features are all enabled, crossterm fails to compile due to differences in the `FileDesc` constructor between the `rustix` and `libc` backends.

This feature combo isn't tested under `--all-features` because that enables `libc` so I amended one of the other CI jobs to include `event-stream`.