### PR TITLE
fix: standardize usage of /dev/tty everywhere

### DIFF
--- a/src/event/source/unix/tty.rs
+++ b/src/event/source/unix/tty.rs
@@ -14,7 +14,7 @@ use filedescriptor::{poll, pollfd, POLLIN};
 #[cfg(feature = "event-stream")]
 use crate::event::sys::Waker;
 use crate::event::{source::EventSource, sys::unix::parse::parse_event, InternalEvent};
-use crate::terminal::sys::file_descriptor::{tty_fd, FileDesc};
+use crate::terminal::sys::file_descriptor::{tty_fd_in, FileDesc};
 
 /// Holds a prototypical Waker and a receiver we can wait on when doing select().
 #[cfg(feature = "event-stream")]
@@ -57,7 +57,7 @@ fn nonblocking_unix_pair() -> io::Result<(UnixStream, UnixStream)> {
 
 impl UnixInternalEventSource {
     pub fn new() -> io::Result<Self> {
-        UnixInternalEventSource::from_file_descriptor(tty_fd()?)
+        UnixInternalEventSource::from_file_descriptor(tty_fd_in()?)
     }
 
     pub(crate) fn from_file_descriptor(input_fd: FileDesc<'static>) -> io::Result<Self> {

--- a/src/terminal/sys/unix.rs
+++ b/src/terminal/sys/unix.rs
@@ -1,13 +1,12 @@
 //! UNIX related logic for terminal manipulation.
 
 use crate::terminal::{
-    sys::file_descriptor::{tty_fd, FileDesc},
+    sys::file_descriptor::{tty_fd_in, tty_fd_out},
     WindowSize,
 };
 #[cfg(feature = "libc")]
 use libc::{
-    cfmakeraw, ioctl, tcgetattr, tcsetattr, termios as Termios, winsize, STDOUT_FILENO, TCSANOW,
-    TIOCGWINSZ,
+    cfmakeraw, ioctl, tcgetattr, tcsetattr, termios as Termios, winsize, TCSANOW, TIOCGWINSZ,
 };
 use parking_lot::Mutex;
 #[cfg(not(feature = "libc"))]
@@ -16,12 +15,9 @@ use rustix::{
     termios::{Termios, Winsize},
 };
 
-use std::{fs::File, io, process};
+use std::{io, process};
 #[cfg(feature = "libc")]
-use std::{
-    mem,
-    os::unix::io::{IntoRawFd, RawFd},
-};
+use std::{mem, os::unix::io::RawFd};
 
 // Some(Termios) -> we're in the raw mode and this is the previous mode
 // None -> we're not in the raw mode
@@ -65,15 +61,9 @@ pub(crate) fn window_size() -> io::Result<WindowSize> {
         ws_ypixel: 0,
     };
 
-    let file = File::open("/dev/tty").map(|file| (FileDesc::new(file.into_raw_fd(), true)));
-    let fd = if let Ok(file) = &file {
-        file.raw_fd()
-    } else {
-        // Fallback to libc::STDOUT_FILENO if /dev/tty is missing
-        STDOUT_FILENO
-    };
+    let fd = tty_fd_out()?;
 
-    if wrap_with_result(unsafe { ioctl(fd, TIOCGWINSZ.into(), &mut size) }).is_ok() {
+    if wrap_with_result(unsafe { ioctl(fd.raw_fd(), TIOCGWINSZ.into(), &mut size) }).is_ok() {
         return Ok(size.into());
     }
 
@@ -82,13 +72,7 @@ pub(crate) fn window_size() -> io::Result<WindowSize> {
 
 #[cfg(not(feature = "libc"))]
 pub(crate) fn window_size() -> io::Result<WindowSize> {
-    let file = File::open("/dev/tty").map(|file| (FileDesc::Owned(file.into())));
-    let fd = if let Ok(file) = &file {
-        file.as_fd()
-    } else {
-        // Fallback to libc::STDOUT_FILENO if /dev/tty is missing
-        rustix::stdio::stdout()
-    };
+    let fd = tty_fd_out()?;
     let size = rustix::termios::tcgetwinsize(fd)?;
     Ok(size.into())
 }
@@ -109,7 +93,7 @@ pub(crate) fn enable_raw_mode() -> io::Result<()> {
         return Ok(());
     }
 
-    let tty = tty_fd()?;
+    let tty = tty_fd_in()?;
     let fd = tty.raw_fd();
     let mut ios = get_terminal_attr(fd)?;
     let original_mode_ios = ios;
@@ -127,7 +111,7 @@ pub(crate) fn enable_raw_mode() -> io::Result<()> {
         return Ok(());
     }
 
-    let tty = tty_fd()?;
+    let tty = tty_fd_in()?;
     let mut ios = get_terminal_attr(&tty)?;
     let original_mode_ios = ios.clone();
     ios.make_raw();
@@ -146,7 +130,7 @@ pub(crate) fn enable_raw_mode() -> io::Result<()> {
 pub(crate) fn disable_raw_mode() -> io::Result<()> {
     let mut original_mode = TERMINAL_MODE_PRIOR_RAW_MODE.lock();
     if let Some(original_mode_ios) = original_mode.as_ref() {
-        let tty = tty_fd()?;
+        let tty = tty_fd_in()?;
         set_terminal_attr(tty.raw_fd(), original_mode_ios)?;
         // Keep it last - remove the original mode only if we were able to switch back
         *original_mode = None;
@@ -158,7 +142,7 @@ pub(crate) fn disable_raw_mode() -> io::Result<()> {
 pub(crate) fn disable_raw_mode() -> io::Result<()> {
     let mut original_mode = TERMINAL_MODE_PRIOR_RAW_MODE.lock();
     if let Some(original_mode_ios) = original_mode.as_ref() {
-        let tty = tty_fd()?;
+        let tty = tty_fd_in()?;
         set_terminal_attr(&tty, original_mode_ios)?;
         // Keep it last - remove the original mode only if we were able to switch back
         *original_mode = None;
@@ -205,7 +189,6 @@ fn read_supports_keyboard_enhancement_raw() -> io::Result<bool> {
         filter::{KeyboardEnhancementFlagsFilter, PrimaryDeviceAttributesFilter},
         poll_internal, read_internal, InternalEvent,
     };
-    use std::io::Write;
     use std::time::Duration;
 
     // This is the recommended method for testing support for the keyboard enhancement protocol.
@@ -219,15 +202,8 @@ fn read_supports_keyboard_enhancement_raw() -> io::Result<bool> {
     // ESC [ c          Query primary device attributes.
     const QUERY: &[u8] = b"\x1B[?u\x1B[c";
 
-    let result = File::open("/dev/tty").and_then(|mut file| {
-        file.write_all(QUERY)?;
-        file.flush()
-    });
-    if result.is_err() {
-        let mut stdout = io::stdout();
-        stdout.write_all(QUERY)?;
-        stdout.flush()?;
-    }
+    let tty = tty_fd_out()?;
+    tty.write(QUERY)?;
 
     loop {
         match poll_internal(


### PR DESCRIPTION
Resolves #919 
Resolves #396 
Supersedes #743

Previous attempts to prefer `/dev/tty` over `stdin` had issues because of problems with polling `/dev/tty` on MacOS. This has been solved for a while with the `use-dev-tty` feature, so now it should be safe to prefer `/dev/tty` everywhere except for the mio event reader on MacOS.

This PR prioritizes the use of `/dev/tty` for both input and output by splitting the `tty_fd` function into `tty_fd_in` and `tty_fd_out` so both can handle the appropriate fallback logic for `stdin` and `stdout` respectively. The only place that needs special care is the MacOS event reader when `use-dev-tty` is not enabled.

The event reader for MacOS has been modified to return an explicit error message when used with piped input to inform users that `use-dev-tty` is required for such use cases. The error message was previously getting swallowed, but will now be returned to the caller.

Finally, the logic to read the cursor position was always writing to `stdout`, causing an error when `stdout` was not a tty. This has been changed to use the new `tty_fd_out` function.

