### PR TITLE
Chanage Wikipedia SGR link to have the proper fragment identifier.

### DIFF
--- a/src/style/types/attribute.rs
+++ b/src/style/types/attribute.rs
@@ -22,7 +22,7 @@ macro_rules! Attribute {
         /// * Only UNIX and Windows 10 terminals do support text attributes.
         /// * Keep in mind that not all terminals support all attributes.
         /// * Crossterm implements almost all attributes listed in the
-        ///   [SGR parameters](https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_parameters).
+        ///   [SGR parameters](https://en.wikipedia.org/wiki/ANSI_escape_code#Select_Graphic_Rendition_parameters).
         ///
         /// | Attribute | Windows | UNIX | Notes |
         /// | :-- | :--: | :--: | :-- |


### PR DESCRIPTION
Wikipedia changed the header of the "Select Graphic Rendition parameters" section. This fixes the [URI Fragment](https://en.wikipedia.org/wiki/URI_fragment) to link to the proper section.