### PR TITLE
Run clippy on all features

### DIFF
--- a/.github/workflows/crossterm_test.yml
+++ b/.github/workflows/crossterm_test.yml
@@ -45,7 +45,7 @@ jobs:
       run: cargo fmt --all -- --check
       continue-on-error: ${{ matrix.can-fail }}
     - name: Clippy
-      run: cargo clippy -- -D clippy::all
+      run: cargo clippy --all-features -- -D clippy::all
       continue-on-error: ${{ matrix.can-fail }}
     - name: Test Build
       run: cargo build

--- a/src/command.rs
+++ b/src/command.rs
@@ -79,7 +79,7 @@ impl<T: Write + ?Sized> QueueableCommand for T {
     ///
     /// - [Command](./trait.Command.html)
     ///
-    ///     The command that you want to queue for later execution.
+    ///   The command that you want to queue for later execution.
     ///
     /// # Examples
     ///
@@ -114,10 +114,10 @@ impl<T: Write + ?Sized> QueueableCommand for T {
     ///
     /// * In the case of UNIX and Windows 10, ANSI codes are written to the given 'writer'.
     /// * In case of Windows versions lower than 10, a direct WinAPI call will be made.
-    ///     The reason for this is that Windows versions lower than 10 do not support ANSI codes,
-    ///     and can therefore not be written to the given `writer`.
-    ///     Therefore, there is no difference between [execute](./trait.ExecutableCommand.html)
-    ///     and [queue](./trait.QueueableCommand.html) for those old Windows versions.
+    ///   The reason for this is that Windows versions lower than 10 do not support ANSI codes,
+    ///   and can therefore not be written to the given `writer`.
+    ///   Therefore, there is no difference between [execute](./trait.ExecutableCommand.html)
+    ///   and [queue](./trait.QueueableCommand.html) for those old Windows versions.
     fn queue(&mut self, command: impl Command) -> io::Result<&mut Self> {
         #[cfg(windows)]
         if !command.is_ansi_code_supported() {
@@ -143,7 +143,7 @@ impl<T: Write + ?Sized> ExecutableCommand for T {
     ///
     /// - [Command](./trait.Command.html)
     ///
-    ///     The command that you want to execute directly.
+    ///   The command that you want to execute directly.
     ///
     /// # Example
     ///
@@ -171,10 +171,10 @@ impl<T: Write + ?Sized> ExecutableCommand for T {
     ///
     /// * In the case of UNIX and Windows 10, ANSI codes are written to the given 'writer'.
     /// * In case of Windows versions lower than 10, a direct WinAPI call will be made.
-    ///     The reason for this is that Windows versions lower than 10 do not support ANSI codes,
-    ///     and can therefore not be written to the given `writer`.
-    ///     Therefore, there is no difference between [execute](./trait.ExecutableCommand.html)
-    ///     and [queue](./trait.QueueableCommand.html) for those old Windows versions.
+    ///   The reason for this is that Windows versions lower than 10 do not support ANSI codes,
+    ///   and can therefore not be written to the given `writer`.
+    ///   Therefore, there is no difference between [execute](./trait.ExecutableCommand.html)
+    ///   and [queue](./trait.QueueableCommand.html) for those old Windows versions.
     fn execute(&mut self, command: impl Command) -> io::Result<&mut Self> {
         self.queue(command)?;
         self.flush()?;

--- a/src/event/source.rs
+++ b/src/event/source.rs
@@ -16,7 +16,7 @@ pub(crate) trait EventSource: Sync + Send {
     /// # Arguments
     ///
     /// * `timeout` - `None` block indefinitely until an event is available, `Some(duration)` blocks
-    ///               for the given timeout
+    ///   for the given timeout
     ///
     /// Returns `Ok(None)` if there's no event available and timeout expires.
     fn try_read(&mut self, timeout: Option<Duration>) -> io::Result<Option<InternalEvent>>;

--- a/src/event/sys/unix/waker/tty.rs
+++ b/src/event/sys/unix/waker/tty.rs
@@ -22,7 +22,7 @@ impl Waker {
     ///
     /// Readiness is set to `Ready::readable()`.
     pub(crate) fn wake(&self) -> io::Result<()> {
-        self.inner.lock().unwrap().write(&[0])?;
+        self.inner.lock().unwrap().write_all(&[0])?;
         Ok(())
     }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -72,11 +72,11 @@ macro_rules! queue {
 ///
 /// - [std::io::Writer](std::io::Write)
 ///
-///     ANSI escape codes are written on the given 'writer', after which they are flushed.
+///   ANSI escape codes are written on the given 'writer', after which they are flushed.
 ///
 /// - [Command](./trait.Command.html)
 ///
-///     One or more commands
+///   One or more commands
 ///
 /// # Examples
 ///
@@ -101,10 +101,10 @@ macro_rules! queue {
 ///
 /// * In the case of UNIX and Windows 10, ANSI codes are written to the given 'writer'.
 /// * In case of Windows versions lower than 10, a direct WinAPI call will be made.
-///     The reason for this is that Windows versions lower than 10 do not support ANSI codes,
-///     and can therefore not be written to the given `writer`.
-///     Therefore, there is no difference between [execute](macro.execute.html)
-///     and [queue](macro.queue.html) for those old Windows versions.
+///   The reason for this is that Windows versions lower than 10 do not support ANSI codes,
+///   and can therefore not be written to the given `writer`.
+///   Therefore, there is no difference between [execute](macro.execute.html)
+///   and [queue](macro.queue.html) for those old Windows versions.
 #[macro_export]
 macro_rules! execute {
     ($writer:expr $(, $command:expr)* $(,)? ) => {{

--- a/src/style/types/color.rs
+++ b/src/style/types/color.rs
@@ -302,12 +302,8 @@ impl<'de> serde::de::Deserialize<'de> for Color {
                             let g = results[1].parse::<u8>();
                             let b = results[2].parse::<u8>();
 
-                            if r.is_ok() && g.is_ok() && b.is_ok() {
-                                return Ok(Color::Rgb {
-                                    r: r.unwrap(),
-                                    g: g.unwrap(),
-                                    b: b.unwrap(),
-                                });
+                            if let (Ok(r), Ok(g), Ok(b)) = (r, g, b) {
+                                return Ok(Color::Rgb { r, g, b });
                             }
                         }
                     } else if let Some(hex) = value.strip_prefix('#') {
@@ -316,12 +312,8 @@ impl<'de> serde::de::Deserialize<'de> for Color {
                             let g = u8::from_str_radix(&hex[2..4], 16);
                             let b = u8::from_str_radix(&hex[4..6], 16);
 
-                            if r.is_ok() && g.is_ok() && b.is_ok() {
-                                return Ok(Color::Rgb {
-                                    r: r.unwrap(),
-                                    g: g.unwrap(),
-                                    b: b.unwrap(),
-                                });
+                            if let (Ok(r), Ok(g), Ok(b)) = (r, g, b) {
+                                return Ok(Color::Rgb { r, g, b });
                             }
                         }
                     }

--- a/src/style/types/color.rs
+++ b/src/style/types/color.rs
@@ -265,7 +265,7 @@ impl<'de> serde::de::Deserialize<'de> for Color {
         D: serde::de::Deserializer<'de>,
     {
         struct ColorVisitor;
-        impl<'de> serde::de::Visitor<'de> for ColorVisitor {
+        impl serde::de::Visitor<'_> for ColorVisitor {
             type Value = Color;
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                 formatter.write_str(


### PR DESCRIPTION
While testing #974, I noticed that clippy is only running on default features in CI. This is an attempt at fixing this.

The changes are completely obvious except for the change in `src/event/sys/unix/waker/tty.rs`. In my opinion, this change is good, too, and maybe even a bugfix, as I don't see what guarantees that a write that's interrupted before anything has been written would wake up a poll, but I'm unsure how to properly test it.

There also are a few doc reindents, which aren't failing the CI. However, it's easier to parse clippy output without their clutter.