### PR TITLE
fix KeyModifiers Display impl

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -870,8 +870,9 @@ impl Display for KeyModifiers {
         for modifier in self.iter() {
             if !first {
                 f.write_str("+")?;
-                first = false;
             }
+
+            first = false;
             match modifier {
                 KeyModifiers::SHIFT => f.write_str("Shift")?,
                 #[cfg(unix)]

--- a/src/event.rs
+++ b/src/event.rs
@@ -1626,6 +1626,20 @@ mod tests {
         assert_eq!(format!("{}", Modifier(RightSuper)), "Right Super");
     }
 
+    #[test]
+    fn key_modifiers_display() {
+        let modifiers = KeyModifiers::SHIFT | KeyModifiers::CONTROL | KeyModifiers::ALT;
+
+        #[cfg(target_os = "macos")]
+        assert_eq!(modifiers.to_string(), "Shift+Control+Option");
+
+        #[cfg(target_os = "windows")]
+        assert_eq!(modifiers.to_string(), "Shift+Ctrl+Alt");
+
+        #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+        assert_eq!(modifiers.to_string(), "Shift+Control+Alt");
+    }
+
     const ESC_PRESSED: KeyEvent =
         KeyEvent::new_with_kind(KeyCode::Esc, KeyModifiers::empty(), KeyEventKind::Press);
     const ESC_RELEASED: KeyEvent =


### PR DESCRIPTION
### Fix KeyModifiers Display impl  

**Issue:**  
The `KeyModifiers` `Display` implementation incorrectly formats modifier keys due to a misplaced flag, causing the output to be concatenated without `+` separators.  

**Current output:** `"ShiftControlOption"`  
**Expected output:** `"Shift+Control+Option"`  

**Fix:**  
- Moved `first = false;` outside the if condition to ensure separator placement after the first iteration  
- Added a test (needs verification on Windows + Linux)