### PR TITLE
refactor: use `is_key_*` helpers for consistency in key event methods

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -674,7 +674,7 @@ impl Event {
     #[inline]
     pub fn as_key_release_event(&self) -> Option<KeyEvent> {
         match self {
-            Event::Key(event) if event.kind == KeyEventKind::Release => Some(*event),
+            Event::Key(event) if self.is_key_release() => Some(*event),
             _ => None,
         }
     }
@@ -683,7 +683,7 @@ impl Event {
     #[inline]
     pub fn as_key_repeat_event(&self) -> Option<KeyEvent> {
         match self {
-            Event::Key(event) if event.kind == KeyEventKind::Repeat => Some(*event),
+            Event::Key(event) if self.is_key_repeat() => Some(*event),
             _ => None,
         }
     }


### PR DESCRIPTION
## Description
This PR refactors `as_key_release_event` and `as_key_repeat_event` to use the existing `is_key_release` and `is_key_repeat` helper methods for consistency. This aligns all `as_key_*_event` methods to follow the same structure, improving maintainability.

## Changes
- `as_key_release_event` now calls `is_key_release()` instead of manually checking `event.kind == KeyEventKind::Release`
- `as_key_repeat_event` now calls `is_key_repeat()` instead of manually checking `event.kind == KeyEventKind::Repeat`

## Rationale
- `is_key_press_event` already uses `is_key_press()`, so the other two methods should follow the same pattern.
- The `matches!` macro used in `is_key_*` functions is more general and can sometimes be optimized better by the compiler.
- Improves code clarity.