### PR TITLE
CI: Add missing continue-on-error annotation

### DIFF
--- a/.github/workflows/crossterm_test.yml
+++ b/.github/workflows/crossterm_test.yml
@@ -73,6 +73,7 @@ jobs:
     - name: Test no default features with windows feature enabled
       if: matrix.os == 'windows-2019'
       run: cargo test --no-default-features --features "windows" -- --nocapture --test-threads 1
+      continue-on-error: ${{ matrix.can-fail }}
     - name: Test Packaging
       if: matrix.rust == 'stable'
       run: cargo package


### PR DESCRIPTION
It looks like the `continue-on-error` for windows with no default features was accidentally left off. I see the nightly build for this step failing today due to a transitive dev dependency: https://github.com/helix-editor/crossterm/actions/runs/14134310684/job/39602227594. Adding the continue-on-error like the other CI tasks papers over that