### PR TITLE
update rustix to 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ filedescriptor = { version = "0.8", optional = true }
 # compatibility.
 libc = { version = "0.2", default-features = false, optional = true }
 mio = { version = "1.0", features = ["os-poll"], optional = true }
-rustix = { version = "0.38.36", default-features = false, features = ["std", "stdio", "termios"] }
+rustix = { version = "1", default-features = false, features = ["std", "stdio", "termios"] }
 signal-hook = { version = "0.3.17", optional = true }
 signal-hook-mio = { version = "0.2.4", features = ["support-v1_0"], optional = true }
 

--- a/src/event/source/unix/tty.rs
+++ b/src/event/source/unix/tty.rs
@@ -71,7 +71,7 @@ impl UnixInternalEventSource {
                 #[cfg(feature = "libc")]
                 pipe::register(libc::SIGWINCH, sender)?;
                 #[cfg(not(feature = "libc"))]
-                pipe::register(rustix::process::Signal::Winch as i32, sender)?;
+                pipe::register(rustix::process::Signal::WINCH.as_raw(), sender)?;
                 receiver
             },
             #[cfg(feature = "event-stream")]


### PR DESCRIPTION
Hi, I noticed that the latest version of rustix is 1.0.4. I think it would be good to update it.

This way, if other crates depend on the latest rustix (e.g., tempfile), we can reduce duplicate compilation.