### PR TITLE
feat: make `document-features` crate optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/lib.rs"
 all-features = true
 
 [features]
-default = ["bracketed-paste", "derive-more", "document-features", "events", "windows", "derive-more"]
+default = ["bracketed-paste", "derive-more", "events", "windows"]
 
 #! ### Default features
 ## Enables triggering [`Event::Paste`](event::Event::Paste) when pasting text into the terminal.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,9 @@ events = ["dep:mio", "dep:signal-hook", "dep:signal-hook-mio"]
 ## Enables windows specific crates.
 windows = ["dep:winapi", "dep:crossterm_winapi"]
 
+## Enables `is_*` helper functions for event enums.
+derive-more = ["dep:derive_more"]
+
 #! ### Optional Features
 
 ## Enables the [EventStream](event::EventStream) struct for async event reading.
@@ -43,9 +46,6 @@ serde = ["dep:serde", "bitflags/serde"]
 
 ## Enables raw file descriptor polling / selecting instead of mio.
 use-dev-tty = ["filedescriptor", "rustix/process"]
-
-## Enables `is_*` helper functions for event enums.
-derive-more = ["dep:derive_more"]
 
 ## Enables interacting with a host clipboard via [`clipboard`](clipboard/index.html)
 osc52 = ["dep:base64"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/lib.rs"
 all-features = true
 
 [features]
-default = ["bracketed-paste", "events", "windows", "derive-more"]
+default = ["bracketed-paste", "derive-more", "document-features", "events", "windows", "derive-more"]
 
 #! ### Default features
 ## Enables triggering [`Event::Paste`](event::Event::Paste) when pasting text into the terminal.
@@ -37,6 +37,9 @@ windows = ["dep:winapi", "dep:crossterm_winapi"]
 derive-more = ["dep:derive_more"]
 
 #! ### Optional Features
+
+## Enables documentation for crate features.
+document-features = ["dep:document-features"]
 
 ## Enables the [EventStream](event::EventStream) struct for async event reading.
 event-stream = ["dep:futures-core", "events"]
@@ -54,7 +57,7 @@ osc52 = ["dep:base64"]
 base64 = { version = "0.22", optional = true }
 bitflags = { version = "2.9" }
 derive_more = { version = "2.0.0", features = ["is_variant"], optional = true }
-document-features = "0.2.11"
+document-features = { version = "0.2.11", optional = true }
 futures-core = { version = "0.3", optional = true, default-features = false }
 parking_lot = "0.12"
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,7 +226,8 @@
 //!   Ok(())
 //! }
 //!```
-//! ## Feature Flags
+//!
+#![cfg_attr(feature = "document-features", doc = "## Feature Flags")]
 #![cfg_attr(feature = "document-features", doc = document_features::document_features!())]
 //!
 //! [write]: https://doc.rust-lang.org/std/io/trait.Write.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,7 +227,7 @@
 //! }
 //!```
 //! ## Feature Flags
-#![doc = document_features::document_features!()]
+#![cfg_attr(feature = "document-features", doc = document_features::document_features!())]
 //!
 //! [write]: https://doc.rust-lang.org/std/io/trait.Write.html
 //! [stdout]: https://doc.rust-lang.org/std/io/fn.stdout.html


### PR DESCRIPTION
The `document-features` crate is unnecessarily included as a default dependency. This PR introduces a new feature flag `document-features` that makes it optional, which is part of the default feature flag set.

I would be inclined to remove this feature from the `default` set but I'll leave that decision to the maintainers.