### PR TITLE
Add `Hash` derive to style types

### DIFF
--- a/src/style/attributes.rs
+++ b/src/style/attributes.rs
@@ -3,7 +3,7 @@ use std::ops::{BitAnd, BitOr, BitXor};
 use crate::style::Attribute;
 
 /// a bitset for all possible attributes
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Attributes(u32);
 
 impl From<Attribute> for Attributes {

--- a/src/style/content_style.rs
+++ b/src/style/content_style.rs
@@ -5,7 +5,7 @@ use std::fmt::Display;
 use crate::style::{Attributes, Color, StyledContent};
 
 /// The style that can be put on content.
-#[derive(Debug, Copy, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, Default, PartialEq, Eq, Hash)]
 pub struct ContentStyle {
     /// The foreground color.
     pub foreground_color: Option<Color>,

--- a/src/style/types/colors.rs
+++ b/src/style/types/colors.rs
@@ -26,7 +26,7 @@ use crate::style::{Color, Colored};
 /// ```
 ///
 /// See [Color](enum.Color.html).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Colors {
     pub foreground: Option<Color>,
     pub background: Option<Color>,


### PR DESCRIPTION
Closes #942

This change allows for more compatibility with data types that require hashing, such as `HashMap` and `HashSet`.