### PR TITLE
Add `try_read` function

### DIFF
--- a/src/event/internal.rs
+++ b/src/event/internal.rs
@@ -52,6 +52,15 @@ where
     reader.read(filter)
 }
 
+/// Reads a single `InternalEvent`. Non-blocking.
+pub(crate) fn try_read<F>(filter: &F) -> Option<InternalEvent>
+where
+    F: Filter,
+{
+    let mut reader = lock_event_reader();
+    reader.try_read(filter)
+}
+
 /// An internal event.
 ///
 /// Encapsulates publicly available `Event` with additional internal


### PR DESCRIPTION
Closes #972

This PR adds a new function, `try_read`, that returns `Some(Event)` from the event queue if events are present, and `None` if otherwise. This could be used to process multiple events at once without using the blocking `read`, which prevents the messy solution provided by @canac in their [issue](https://github.com/crossterm-rs/crossterm/issues/972).