### PR TITLE
feat(event): report the kitty protocol's base layout key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,22 @@
 # Unreleased
 
+## Added ⭐
+
+- Report the Kitty keyboard protocol's *base layout key* as
+  `KeyEvent::base_layout_code`, so shortcuts can be matched by physical key
+  regardless of the active keyboard layout (#968). Set only when
+  `KeyboardEnhancementFlags::REPORT_ALTERNATE_KEYS` is enabled.
+
 ## Breaking ⚠️
 
 - Raise the minimum supported Rust version from 1.63 to 1.85.
 - Remove `IsTty` trait.
   Use the standard library's [`std::io::IsTerminal`](https://doc.rust-lang.org/std/io/trait.IsTerminal.html) trait instead,
   which provides equivalent functionality.
+- `KeyEvent` gained a `base_layout_code` field: struct-literal construction and
+  exhaustive destructuring need updating. The `KeyEvent::new*` constructors,
+  `PartialEq` and `Hash` are unaffected — the new field takes no part in
+  equality, so comparisons against manually built events keep working.
 
 ## Changed ⚙️
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Unreleased
 
+## Added ⭐
+
+- Report the Kitty keyboard protocol's *base layout key* as
+  `KeyEvent::base_layout_code`, so shortcuts can be matched by physical key
+  regardless of the active keyboard layout (#968). Set only when
+  `KeyboardEnhancementFlags::REPORT_ALTERNATE_KEYS` is enabled.
+
+## Breaking ⚠️
+
+- `KeyEvent` gained a `base_layout_code` field: struct-literal construction and
+  exhaustive destructuring need updating. The `KeyEvent::new*` constructors,
+  `PartialEq` and `Hash` are unaffected — the new field takes no part in
+  equality, so comparisons against manually built events keep working.
+
 ## Fixed 🐛
 
 - Fix integer underflow in mouse / cursor-position parsers when coord

--- a/src/event.rs
+++ b/src/event.rs
@@ -933,6 +933,24 @@ pub struct KeyEvent {
     /// Only set if [`KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES`] has been enabled with
     /// [`PushKeyboardEnhancementFlags`].
     pub state: KeyEventState,
+    /// The key at the same physical position on a standard PC-101 keyboard,
+    /// independent of the active keyboard layout.
+    ///
+    /// This is what makes layout-independent shortcuts possible: with a Cyrillic
+    /// layout active, the physical `C` key reports `KeyCode::Char('с')` in
+    /// [`code`](Self::code) and `Some(KeyCode::Char('c'))` here, so an
+    /// application can match `Ctrl+C` regardless of the layout the user types in.
+    ///
+    /// Only set if [`KeyboardEnhancementFlags::REPORT_ALTERNATE_KEYS`] has been
+    /// enabled with [`PushKeyboardEnhancementFlags`], and only on Unix — the
+    /// Windows console API does not report it.
+    ///
+    /// This field deliberately takes no part in [`PartialEq`]/[`Hash`], so that
+    /// comparing against a manually constructed event — the common
+    /// `event == KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL)`
+    /// pattern — keeps working once the enhancement is enabled.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub base_layout_code: Option<KeyCode>,
 }
 
 impl KeyEvent {
@@ -942,6 +960,7 @@ impl KeyEvent {
             modifiers,
             kind: KeyEventKind::Press,
             state: KeyEventState::empty(),
+            base_layout_code: None,
         }
     }
 
@@ -955,6 +974,7 @@ impl KeyEvent {
             modifiers,
             kind,
             state: KeyEventState::empty(),
+            base_layout_code: None,
         }
     }
 
@@ -969,7 +989,15 @@ impl KeyEvent {
             modifiers,
             kind,
             state,
+            base_layout_code: None,
         }
+    }
+
+    /// Returns the event with [`base_layout_code`](Self::base_layout_code) set.
+    #[must_use = "this returns a new event instead of modifying the original"]
+    pub fn with_base_layout_code(mut self, base_layout_code: Option<KeyCode>) -> KeyEvent {
+        self.base_layout_code = base_layout_code;
+        self
     }
 
     // modifies the KeyEvent,
@@ -1012,23 +1040,29 @@ impl From<KeyCode> for KeyEvent {
             modifiers: KeyModifiers::empty(),
             kind: KeyEventKind::Press,
             state: KeyEventState::empty(),
+            base_layout_code: None,
         }
     }
 }
 
 impl PartialEq for KeyEvent {
     fn eq(&self, other: &KeyEvent) -> bool {
+        // `base_layout_code` is metadata about the same key press, not part of
+        // its identity: including it would break `event == KeyEvent::new(...)`
+        // comparisons as soon as `REPORT_ALTERNATE_KEYS` is enabled.
         let KeyEvent {
             code: lhs_code,
             modifiers: lhs_modifiers,
             kind: lhs_kind,
             state: lhs_state,
+            base_layout_code: _,
         } = self.normalize_case();
         let KeyEvent {
             code: rhs_code,
             modifiers: rhs_modifiers,
             kind: rhs_kind,
             state: rhs_state,
+            base_layout_code: _,
         } = other.normalize_case();
         (lhs_code == rhs_code)
             && (lhs_modifiers == rhs_modifiers)
@@ -1041,11 +1075,14 @@ impl Eq for KeyEvent {}
 
 impl Hash for KeyEvent {
     fn hash<H: Hasher>(&self, hash_state: &mut H) {
+        // Excluded for the same reason as in `PartialEq`, and to keep `Hash`
+        // consistent with it.
         let KeyEvent {
             code,
             modifiers,
             kind,
             state,
+            base_layout_code: _,
         } = self.normalize_case();
         code.hash(hash_state);
         modifiers.hash(hash_state);

--- a/src/event.rs
+++ b/src/event.rs
@@ -934,6 +934,24 @@ pub struct KeyEvent {
     /// Only set if [`KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES`] has been enabled with
     /// [`PushKeyboardEnhancementFlags`].
     pub state: KeyEventState,
+    /// The key at the same physical position on a standard PC-101 keyboard,
+    /// independent of the active keyboard layout.
+    ///
+    /// This is what makes layout-independent shortcuts possible: with a Cyrillic
+    /// layout active, the physical `C` key reports `KeyCode::Char('с')` in
+    /// [`code`](Self::code) and `Some(KeyCode::Char('c'))` here, so an
+    /// application can match `Ctrl+C` regardless of the layout the user types in.
+    ///
+    /// Only set if [`KeyboardEnhancementFlags::REPORT_ALTERNATE_KEYS`] has been
+    /// enabled with [`PushKeyboardEnhancementFlags`], and only on Unix — the
+    /// Windows console API does not report it.
+    ///
+    /// This field deliberately takes no part in [`PartialEq`]/[`Hash`], so that
+    /// comparing against a manually constructed event — the common
+    /// `event == KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL)`
+    /// pattern — keeps working once the enhancement is enabled.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub base_layout_code: Option<KeyCode>,
 }
 
 impl KeyEvent {
@@ -943,6 +961,7 @@ impl KeyEvent {
             modifiers,
             kind: KeyEventKind::Press,
             state: KeyEventState::empty(),
+            base_layout_code: None,
         }
     }
 
@@ -956,6 +975,7 @@ impl KeyEvent {
             modifiers,
             kind,
             state: KeyEventState::empty(),
+            base_layout_code: None,
         }
     }
 
@@ -970,7 +990,15 @@ impl KeyEvent {
             modifiers,
             kind,
             state,
+            base_layout_code: None,
         }
+    }
+
+    /// Returns the event with [`base_layout_code`](Self::base_layout_code) set.
+    #[must_use = "this returns a new event instead of modifying the original"]
+    pub fn with_base_layout_code(mut self, base_layout_code: Option<KeyCode>) -> KeyEvent {
+        self.base_layout_code = base_layout_code;
+        self
     }
 
     // modifies the KeyEvent,
@@ -1013,23 +1041,29 @@ impl From<KeyCode> for KeyEvent {
             modifiers: KeyModifiers::empty(),
             kind: KeyEventKind::Press,
             state: KeyEventState::empty(),
+            base_layout_code: None,
         }
     }
 }
 
 impl PartialEq for KeyEvent {
     fn eq(&self, other: &KeyEvent) -> bool {
+        // `base_layout_code` is metadata about the same key press, not part of
+        // its identity: including it would break `event == KeyEvent::new(...)`
+        // comparisons as soon as `REPORT_ALTERNATE_KEYS` is enabled.
         let KeyEvent {
             code: lhs_code,
             modifiers: lhs_modifiers,
             kind: lhs_kind,
             state: lhs_state,
+            base_layout_code: _,
         } = self.normalize_case();
         let KeyEvent {
             code: rhs_code,
             modifiers: rhs_modifiers,
             kind: rhs_kind,
             state: rhs_state,
+            base_layout_code: _,
         } = other.normalize_case();
         (lhs_code == rhs_code)
             && (lhs_modifiers == rhs_modifiers)
@@ -1042,11 +1076,14 @@ impl Eq for KeyEvent {}
 
 impl Hash for KeyEvent {
     fn hash<H: Hasher>(&self, hash_state: &mut H) {
+        // Excluded for the same reason as in `PartialEq`, and to keep `Hash`
+        // consistent with it.
         let KeyEvent {
             code,
             modifiers,
             kind,
             state,
+            base_layout_code: _,
         } = self.normalize_case();
         code.hash(hash_state);
         modifiers.hash(hash_state);

--- a/src/event/sys/unix/parse.rs
+++ b/src/event/sys/unix/parse.rs
@@ -591,29 +591,48 @@ pub(crate) fn parse_csi_u_encoded_key_code(buffer: &[u8]) -> io::Result<Option<I
         }
     }
 
-    // When the "report alternate keys" flag is enabled in the Kitty Keyboard Protocol
-    // and the terminal sends a keyboard event containing shift, the sequence will
-    // contain an additional codepoint separated by a ':' character which contains
-    // the shifted character according to the keyboard layout.
+    // When the "report alternate keys" flag is enabled in the Kitty Keyboard Protocol,
+    // the first field carries up to two more codepoints separated by ':' characters:
+    // the shifted key and the base layout key, in that order. Either may be absent or
+    // empty (`CSI 1076::108;5u` reports a base layout key but no shifted key), so both
+    // are read positionally, before either is used.
+    let shifted_key = next_alternate_key(&mut codepoints);
+    let base_layout_key = next_alternate_key(&mut codepoints);
+
+    // The shifted key is the character the active layout produces with shift held, so
+    // it replaces the key code and consumes the modifier.
     if modifiers.contains(KeyModifiers::SHIFT) {
-        if let Some(shifted_c) = codepoints
-            .next()
-            .and_then(|codepoint| codepoint.parse::<u32>().ok())
-            .and_then(char::from_u32)
-        {
+        if let Some(shifted_c) = shifted_key {
             keycode = KeyCode::Char(shifted_c);
             modifiers.set(KeyModifiers::SHIFT, false);
         }
     }
 
-    let input_event = Event::Key(KeyEvent::new_with_kind_and_state(
-        keycode,
-        modifiers,
-        kind,
-        state_from_keycode | state_from_modifiers,
-    ));
+    let input_event = Event::Key(
+        KeyEvent::new_with_kind_and_state(
+            keycode,
+            modifiers,
+            kind,
+            state_from_keycode | state_from_modifiers,
+        )
+        // The base layout key is the key at the same physical position on a standard
+        // PC-101 keyboard, which lets applications match shortcuts by physical key
+        // regardless of the layout the user types in.
+        .with_base_layout_code(base_layout_key.map(KeyCode::Char)),
+    );
 
     Ok(Some(InternalEvent::Event(input_event)))
+}
+
+/// Reads the next `:`-separated alternate key of a `CSI u` key field.
+///
+/// Returns `None` when the alternate is absent or empty, which the Kitty Keyboard
+/// Protocol allows for any of them.
+fn next_alternate_key<'a>(codepoints: &mut impl Iterator<Item = &'a str>) -> Option<char> {
+    codepoints
+        .next()
+        .and_then(|codepoint| codepoint.parse::<u32>().ok())
+        .and_then(char::from_u32)
 }
 
 pub(crate) fn parse_csi_special_key_code(buffer: &[u8]) -> io::Result<Option<InternalEvent>> {
@@ -865,9 +884,23 @@ pub(crate) fn parse_utf8_char(buffer: &[u8]) -> io::Result<Option<char>> {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
     use crate::event::{KeyEventState, KeyModifiers, MouseButton, MouseEvent};
 
     use super::*;
+
+    /// Parses a sequence that is expected to yield exactly one key event.
+    ///
+    /// Needed where a field is asserted directly instead of through
+    /// `assert_eq!` on the whole event, which compares by key identity only.
+    fn key_event(bytes: &[u8]) -> KeyEvent {
+        match parse_event(bytes, false).unwrap() {
+            Some(InternalEvent::Event(Event::Key(key))) => key,
+            other => panic!("expected a key event, got {:?}", other),
+        }
+    }
 
     #[test]
     fn test_esc_key() {
@@ -1546,6 +1579,44 @@ mod tests {
                 KeyModifiers::ALT,
             )))),
         );
+    }
+
+    #[test]
+    fn test_parse_csi_u_with_base_layout_key() {
+        // The physical `L` key pressed with ctrl on a Cyrillic layout: the layout
+        // reports `д` (U+0434), its shifted form is `Д` (U+0414), and the key at the
+        // same position on a PC-101 keyboard is `l` (U+006C).
+        let event = key_event(b"\x1B[1076:1044:108;5u");
+        assert_eq!(event.code, KeyCode::Char('\u{434}'));
+        assert_eq!(event.modifiers, KeyModifiers::CONTROL);
+        assert_eq!(event.base_layout_code, Some(KeyCode::Char('l')));
+
+        // The shifted key may be omitted while the base layout key is present.
+        let event = key_event(b"\x1B[1076::108;5u");
+        assert_eq!(event.code, KeyCode::Char('\u{434}'));
+        assert_eq!(event.base_layout_code, Some(KeyCode::Char('l')));
+
+        // Without the enhancement (or on a layout where the key is its own base),
+        // no alternates are reported.
+        assert_eq!(key_event(b"\x1B[97;5u").base_layout_code, None);
+        assert_eq!(key_event(b"\x1B[97:65;2u").base_layout_code, None);
+    }
+
+    #[test]
+    fn test_base_layout_key_does_not_affect_equality() {
+        // Applications compare against manually built events; reporting alternates
+        // must not break that, so the base layout key is not part of the identity.
+        let reported = key_event(b"\x1B[1076:1044:108;5u");
+        assert_eq!(
+            reported,
+            KeyEvent::new(KeyCode::Char('\u{434}'), KeyModifiers::CONTROL)
+        );
+
+        let mut with_base = DefaultHasher::new();
+        reported.hash(&mut with_base);
+        let mut without_base = DefaultHasher::new();
+        KeyEvent::new(KeyCode::Char('\u{434}'), KeyModifiers::CONTROL).hash(&mut without_base);
+        assert_eq!(with_base.finish(), without_base.finish());
     }
 
     #[test]

--- a/src/event/sys/unix/parse.rs
+++ b/src/event/sys/unix/parse.rs
@@ -590,29 +590,48 @@ pub(crate) fn parse_csi_u_encoded_key_code(buffer: &[u8]) -> io::Result<Option<I
         }
     }
 
-    // When the "report alternate keys" flag is enabled in the Kitty Keyboard Protocol
-    // and the terminal sends a keyboard event containing shift, the sequence will
-    // contain an additional codepoint separated by a ':' character which contains
-    // the shifted character according to the keyboard layout.
+    // When the "report alternate keys" flag is enabled in the Kitty Keyboard Protocol,
+    // the first field carries up to two more codepoints separated by ':' characters:
+    // the shifted key and the base layout key, in that order. Either may be absent or
+    // empty (`CSI 1076::108;5u` reports a base layout key but no shifted key), so both
+    // are read positionally, before either is used.
+    let shifted_key = next_alternate_key(&mut codepoints);
+    let base_layout_key = next_alternate_key(&mut codepoints);
+
+    // The shifted key is the character the active layout produces with shift held, so
+    // it replaces the key code and consumes the modifier.
     if modifiers.contains(KeyModifiers::SHIFT) {
-        if let Some(shifted_c) = codepoints
-            .next()
-            .and_then(|codepoint| codepoint.parse::<u32>().ok())
-            .and_then(char::from_u32)
-        {
+        if let Some(shifted_c) = shifted_key {
             keycode = KeyCode::Char(shifted_c);
             modifiers.set(KeyModifiers::SHIFT, false);
         }
     }
 
-    let input_event = Event::Key(KeyEvent::new_with_kind_and_state(
-        keycode,
-        modifiers,
-        kind,
-        state_from_keycode | state_from_modifiers,
-    ));
+    let input_event = Event::Key(
+        KeyEvent::new_with_kind_and_state(
+            keycode,
+            modifiers,
+            kind,
+            state_from_keycode | state_from_modifiers,
+        )
+        // The base layout key is the key at the same physical position on a standard
+        // PC-101 keyboard, which lets applications match shortcuts by physical key
+        // regardless of the layout the user types in.
+        .with_base_layout_code(base_layout_key.map(KeyCode::Char)),
+    );
 
     Ok(Some(InternalEvent::Event(input_event)))
+}
+
+/// Reads the next `:`-separated alternate key of a `CSI u` key field.
+///
+/// Returns `None` when the alternate is absent or empty, which the Kitty Keyboard
+/// Protocol allows for any of them.
+fn next_alternate_key<'a>(codepoints: &mut impl Iterator<Item = &'a str>) -> Option<char> {
+    codepoints
+        .next()
+        .and_then(|codepoint| codepoint.parse::<u32>().ok())
+        .and_then(char::from_u32)
 }
 
 pub(crate) fn parse_csi_special_key_code(buffer: &[u8]) -> io::Result<Option<InternalEvent>> {
@@ -864,9 +883,23 @@ pub(crate) fn parse_utf8_char(buffer: &[u8]) -> io::Result<Option<char>> {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
     use crate::event::{KeyEventState, KeyModifiers, MouseButton, MouseEvent};
 
     use super::*;
+
+    /// Parses a sequence that is expected to yield exactly one key event.
+    ///
+    /// Needed where a field is asserted directly instead of through
+    /// `assert_eq!` on the whole event, which compares by key identity only.
+    fn key_event(bytes: &[u8]) -> KeyEvent {
+        match parse_event(bytes, false).unwrap() {
+            Some(InternalEvent::Event(Event::Key(key))) => key,
+            other => panic!("expected a key event, got {:?}", other),
+        }
+    }
 
     #[test]
     fn test_esc_key() {
@@ -1545,6 +1578,44 @@ mod tests {
                 KeyModifiers::ALT,
             )))),
         );
+    }
+
+    #[test]
+    fn test_parse_csi_u_with_base_layout_key() {
+        // The physical `L` key pressed with ctrl on a Cyrillic layout: the layout
+        // reports `д` (U+0434), its shifted form is `Д` (U+0414), and the key at the
+        // same position on a PC-101 keyboard is `l` (U+006C).
+        let event = key_event(b"\x1B[1076:1044:108;5u");
+        assert_eq!(event.code, KeyCode::Char('\u{434}'));
+        assert_eq!(event.modifiers, KeyModifiers::CONTROL);
+        assert_eq!(event.base_layout_code, Some(KeyCode::Char('l')));
+
+        // The shifted key may be omitted while the base layout key is present.
+        let event = key_event(b"\x1B[1076::108;5u");
+        assert_eq!(event.code, KeyCode::Char('\u{434}'));
+        assert_eq!(event.base_layout_code, Some(KeyCode::Char('l')));
+
+        // Without the enhancement (or on a layout where the key is its own base),
+        // no alternates are reported.
+        assert_eq!(key_event(b"\x1B[97;5u").base_layout_code, None);
+        assert_eq!(key_event(b"\x1B[97:65;2u").base_layout_code, None);
+    }
+
+    #[test]
+    fn test_base_layout_key_does_not_affect_equality() {
+        // Applications compare against manually built events; reporting alternates
+        // must not break that, so the base layout key is not part of the identity.
+        let reported = key_event(b"\x1B[1076:1044:108;5u");
+        assert_eq!(
+            reported,
+            KeyEvent::new(KeyCode::Char('\u{434}'), KeyModifiers::CONTROL)
+        );
+
+        let mut with_base = DefaultHasher::new();
+        reported.hash(&mut with_base);
+        let mut without_base = DefaultHasher::new();
+        KeyEvent::new(KeyCode::Char('\u{434}'), KeyModifiers::CONTROL).hash(&mut without_base);
+        assert_eq!(with_base.finish(), without_base.finish());
     }
 
     #[test]


### PR DESCRIPTION
Closes #968.

## Problem

The kitty keyboard protocol's *report alternate keys* enhancement (`0b100`) sends up to two extra codepoints with each key: the shifted key and the **base layout key** — "the key corresponding to the physical key in the standard PC-101 key layout". The parser reads the shifted one (and only when shift is held), then drops the rest.

Without the base layout key an application has no way to match a shortcut by physical key. Under a Cyrillic, Greek, Hebrew or Georgian layout the terminal faithfully reports the layout's character, so every `Ctrl+<letter>` binding is dead — which is precisely what the enhancement exists to solve; the spec's own example is the Cyrillic `ctrl+С` → `ctrl+c` case.

## Change

* Parse both alternates positionally. Besides making the base layout key reachable at all, this fixes a latent bug: any alternate may be empty (`CSI 1076::108;5u` reports a base layout key and no shifted key), and the old `codepoints.next()` — reached only under shift — would then hand out the wrong slot.
* Expose the base layout key as `KeyEvent::base_layout_code: Option<KeyCode>`, alongside the existing enhancement-gated `kind`/`state` fields, plus a `with_base_layout_code` builder.

## The one decision worth your review

`base_layout_code` deliberately takes **no part in `PartialEq`/`Hash`**.

It describes the same key press rather than identifying it, and including it would silently break the ubiquitous

```rust
if event == KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL) { … }
```

comparison for every application the moment it enables `REPORT_ALTERNATE_KEYS` — which would make the feature unusable in practice. The manual `PartialEq`/`Hash` impls destructure `KeyEvent` exhaustively, so this is an explicit `base_layout_code: _`, not an omission.

Derived `PartialOrd`/`Ord` *do* include the new field, which is inconsistent with `Eq` — but they already disagree with it today via `normalize_case`, so I left that pre-existing wart alone rather than widen the diff. Happy to align them if you would prefer.

**Scope:** I did not expose the shifted key. It is already reflected in `code` by the existing substitution, so a separate field would be redundant. #968 asks for both — say the word and I will add it.

## Compatibility

Breaking only for struct-literal construction and exhaustive destructuring of `KeyEvent`; the `new*` constructors, equality and hashing are unaffected, and `serde(default)` keeps older payloads deserializable. **No existing test needed updating** — the suite passes unchanged, which is the concrete form of that claim.

## Tests

Two new tests in the `CSI u` parser: alternates parsed (with a shifted key, without one, and with no alternates at all), and the equality/hash invariant above.

`cargo fmt --check`, `cargo clippy --all-features -- -D clippy::all` and `cargo test --all-features` are green on Linux (Ubuntu 24.04, 119 lib tests) and Windows.

One note for adopters, learned from wiring this into a TUI end to end: the base layout key should not be honoured for ASCII characters. On AZERTY the key labelled `A` sits at the US `Q` position, so it arrives as `Char('a')` with a base layout key of `q` — taking it unconditionally turns `Ctrl+A` into `Ctrl+Q`. Matching by physical key is what you want for non-ASCII layouts; for Latin ones, the label is.