### PR TITLE
Replace derive_more event helpers with a local macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Remove `IsTty` trait.
   Use the standard library's [`std::io::IsTerminal`](https://doc.rust-lang.org/std/io/trait.IsTerminal.html) trait instead,
   which provides equivalent functionality.
+- Remove the `derive-more` feature and `derive_more` dependency. Event variant helper
+  methods are always available.
 
 ## Changed ⚙️
 
@@ -33,7 +35,6 @@
 - Derive standard traits for "SetCursorStyle" (#909)
 - Add query_keyboard_enhancement_flags to read enabled flags (#958)
 - Add is_* and as_* methods to the event enums (#949)
-- Add a feature flag for derive_more impls (#970)
 - Update rustix to 1.0 (#982)
 
 ## Breaking ⚠️

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,15 +183,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "convert_case"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,7 +195,6 @@ dependencies = [
  "base64",
  "bitflags",
  "crossterm_winapi",
- "derive_more",
  "document-features",
  "filedescriptor",
  "futures",
@@ -232,28 +222,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
-]
-
-[[package]]
-name = "derive_more"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
-dependencies = [
- "derive_more-impl",
-]
-
-[[package]]
-name = "derive_more-impl"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
-dependencies = [
- "convert_case",
- "proc-macro2",
- "quote",
- "rustc_version",
- "syn 2.0.119",
 ]
 
 [[package]]
@@ -576,15 +544,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -602,12 +561,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "semver"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -831,12 +784,6 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ path = "src/lib.rs"
 all-features = true
 
 [features]
-default = ["bracketed-paste", "derive-more", "events", "windows"]
+default = ["bracketed-paste", "events", "windows"]
 
 #! ### Default features
 ## Enables triggering [`Event::Paste`](event::Event::Paste) when pasting text into the terminal.
@@ -34,9 +34,6 @@ events = ["dep:mio", "dep:signal-hook", "dep:signal-hook-mio"]
 
 ## Enables windows specific crates.
 windows = ["dep:winapi", "dep:crossterm_winapi"]
-
-## Enables `is_*` helper functions for event enums.
-derive-more = ["dep:derive_more"]
 
 #! ### Optional Features
 
@@ -58,7 +55,6 @@ osc52 = ["dep:base64"]
 [dependencies]
 base64 = { version = "0.23", optional = true }
 bitflags = { version = "2.9" }
-derive_more = { version = "2.0.0", features = ["is_variant"], optional = true }
 document-features = { version = "0.2.11", optional = true }
 futures-core = { version = "0.3.31", optional = true, default-features = false }
 parking_lot = "0.12.1"

--- a/README.md
+++ b/README.md
@@ -153,7 +153,6 @@ features = ["event-stream"]
 | `serde`        | (De)serializing of events.                   |
 | `events`        | Reading input/system events (enabled by default) |
 | `filedescriptor` | Use raw filedescriptor for all events rather then mio dependency |
-| `derive-more`  | Adds `is_*` helper functions for event types |
 | `osc52`        | Enables crossterm::clipboard                 |
 
 
@@ -172,7 +171,6 @@ This can disable `mio` / `signal-hook` / `signal-hook-mio` dependencies.
 | `winapi`       | Used for low-level windows system calls which ANSI codes can't replace           | windows only                          |
 | `futures-core` | For async stream of events                                                       | only with `event-stream` feature flag |
 | `serde`        | ***ser***ializing and ***de***serializing of events                              | only with `serde` feature flag        |
-| `derive_more`  | Adds `is_*` helper functions for event types                                     | optional (`derive-more` feature), included by default |
 | `base64`       | Encoding clipboard data for OSC52 sequences in crossterm::clipboard              | only with `osc52` feature flag        |
 
 ### Other Resources

--- a/src/event.rs
+++ b/src/event.rs
@@ -127,8 +127,6 @@ pub(crate) mod stream;
 pub(crate) mod sys;
 pub(crate) mod timeout;
 
-#[cfg(feature = "derive-more")]
-use derive_more::derive::IsVariant;
 #[cfg(feature = "event-stream")]
 pub use stream::EventStream;
 
@@ -527,7 +525,6 @@ impl Command for PopKeyboardEnhancementFlags {
 
 /// Represents an event.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "derive-more", derive(IsVariant))]
 #[cfg_attr(not(feature = "bracketed-paste"), derive(Copy))]
 #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, Clone, Hash)]
 pub enum Event {
@@ -546,6 +543,61 @@ pub enum Event {
     /// A resize event with new dimensions after resize (columns, rows).
     /// **Note** that resize events can occur in batches.
     Resize(u16, u16),
+}
+
+/// Implements `is_*` predicates for unit and tuple enum variants.
+///
+/// Entries use the same left-to-right shape as `match` arms:
+/// `Variant` or `Variant(..)`, followed by `=>` and the method name. The
+/// method name is explicit because `macro_rules!` cannot construct an
+/// identifier such as `is_focus_gained` from `FocusGained`.
+///
+/// Attributes on an entry are applied to the generated method. This keeps
+/// feature-gated helpers, such as `Event::is_paste`, aligned with their
+/// variants.
+///
+/// Variants whose payload needs to be compared belong in a handwritten
+/// method instead; see the `KeyCode` helpers below. Generated methods are
+/// `const`, inline, and `must_use`.
+macro_rules! impl_is_variant {
+    (
+        $type:ident {
+            $(
+                $(#[$meta:meta])*
+                $variant:ident $(($field:tt))? => $method:ident
+            ),* $(,)?
+        }
+    ) => {
+        impl $type {
+            $(
+                $(#[$meta])*
+                #[doc = concat!(
+                    "Returns `true` if this value is the `",
+                    stringify!($type),
+                    "::",
+                    stringify!($variant),
+                    "` variant. Returns `false` otherwise."
+                )]
+                #[inline]
+                #[must_use]
+                pub const fn $method(&self) -> bool {
+                    matches!(self, Self::$variant $(($field))?)
+                }
+            )*
+        }
+    };
+}
+
+impl_is_variant! {
+    Event {
+        FocusGained => is_focus_gained,
+        FocusLost => is_focus_lost,
+        Key(..) => is_key,
+        Mouse(..) => is_mouse,
+        #[cfg(feature = "bracketed-paste")]
+        Paste(..) => is_paste,
+        Resize(..) => is_resize,
+    }
 }
 
 impl Event {
@@ -778,7 +830,6 @@ pub struct MouseEvent {
 /// `MouseEventKind::Up` and `MouseEventKind::Drag` events. `MouseButton::Left`
 /// is returned if we don't know which button was used.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "derive-more", derive(IsVariant))]
 #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, Clone, Copy, Hash)]
 pub enum MouseEventKind {
     /// Pressed mouse button. Contains the button that was pressed.
@@ -799,9 +850,21 @@ pub enum MouseEventKind {
     ScrollRight,
 }
 
+impl_is_variant! {
+    MouseEventKind {
+        Down(..) => is_down,
+        Up(..) => is_up,
+        Drag(..) => is_drag,
+        Moved => is_moved,
+        ScrollDown => is_scroll_down,
+        ScrollUp => is_scroll_up,
+        ScrollLeft => is_scroll_left,
+        ScrollRight => is_scroll_right,
+    }
+}
+
 /// Represents a mouse button.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "derive-more", derive(IsVariant))]
 #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, Clone, Copy, Hash)]
 pub enum MouseButton {
     /// Left mouse button.
@@ -810,6 +873,14 @@ pub enum MouseButton {
     Right,
     /// Middle mouse button.
     Middle,
+}
+
+impl_is_variant! {
+    MouseButton {
+        Left => is_left,
+        Right => is_right,
+        Middle => is_middle,
+    }
 }
 
 bitflags! {
@@ -883,12 +954,19 @@ impl Display for KeyModifiers {
 
 /// Represents a keyboard event kind.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "derive-more", derive(IsVariant))]
 #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, Clone, Copy, Hash)]
 pub enum KeyEventKind {
     Press,
     Repeat,
     Release,
+}
+
+impl_is_variant! {
+    KeyEventKind {
+        Press => is_press,
+        Repeat => is_repeat,
+        Release => is_release,
+    }
 }
 
 bitflags! {
@@ -1204,7 +1282,6 @@ impl Display for ModifierKeyCode {
 
 /// Represents a key.
 #[derive(Debug, PartialOrd, Ord, PartialEq, Eq, Clone, Copy, Hash)]
-#[cfg_attr(feature = "derive-more", derive(IsVariant))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum KeyCode {
     /// Backspace key (Delete on macOS, Backspace on other platforms).
@@ -1238,12 +1315,10 @@ pub enum KeyCode {
     /// F key.
     ///
     /// `KeyCode::F(1)` represents F1 key, etc.
-    #[cfg_attr(feature = "derive-more", is_variant(ignore))]
     F(u8),
     /// A character.
     ///
     /// `KeyCode::Char('c')` represents `c` character, etc.
-    #[cfg_attr(feature = "derive-more", is_variant(ignore))]
     Char(char),
     /// Null.
     Null,
@@ -1296,7 +1371,6 @@ pub enum KeyCode {
     /// **Note:** these keys can only be read if
     /// [`KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES`] has been enabled with
     /// [`PushKeyboardEnhancementFlags`].
-    #[cfg_attr(feature = "derive-more", is_variant(ignore))]
     Media(MediaKeyCode),
     /// A modifier key.
     ///
@@ -1304,8 +1378,36 @@ pub enum KeyCode {
     /// [`KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES`] and
     /// [`KeyboardEnhancementFlags::REPORT_ALL_KEYS_AS_ESCAPE_CODES`] have been enabled with
     /// [`PushKeyboardEnhancementFlags`].
-    #[cfg_attr(feature = "derive-more", is_variant(ignore))]
     Modifier(ModifierKeyCode),
+}
+
+// `F`, `Char`, `Media`, and `Modifier` have payload-aware methods below.
+impl_is_variant! {
+    KeyCode {
+        Backspace => is_backspace,
+        Enter => is_enter,
+        Left => is_left,
+        Right => is_right,
+        Up => is_up,
+        Down => is_down,
+        Home => is_home,
+        End => is_end,
+        PageUp => is_page_up,
+        PageDown => is_page_down,
+        Tab => is_tab,
+        BackTab => is_back_tab,
+        Delete => is_delete,
+        Insert => is_insert,
+        Null => is_null,
+        Esc => is_esc,
+        CapsLock => is_caps_lock,
+        ScrollLock => is_scroll_lock,
+        NumLock => is_num_lock,
+        PrintScreen => is_print_screen,
+        Pause => is_pause,
+        Menu => is_menu,
+        KeypadBegin => is_keypad_begin,
+    }
 }
 
 impl KeyCode {
@@ -1617,7 +1719,6 @@ mod tests {
         modifiers: KeyModifiers::empty(),
     };
 
-    #[cfg(feature = "derive-more")]
     #[test]
     fn event_is() {
         let event = Event::FocusGained;
@@ -1665,6 +1766,22 @@ mod tests {
             assert!(event.is_paste());
             assert!(!event.is_key());
         }
+    }
+
+    #[test]
+    fn enum_variant_is() {
+        let mouse_kind = MouseEventKind::Down(MouseButton::Left);
+        assert!(mouse_kind.is_down());
+        assert!(!mouse_kind.is_up());
+
+        assert!(MouseButton::Left.is_left());
+        assert!(!MouseButton::Left.is_right());
+
+        assert!(KeyEventKind::Press.is_press());
+        assert!(!KeyEventKind::Press.is_release());
+
+        assert!(KeyCode::Backspace.is_backspace());
+        assert!(!KeyCode::Backspace.is_enter());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This removes the `derive_more` dependency and feature used to provide the event enum `is_*` methods.

The public methods and their behavior remain unchanged. They are now generated by a small private `macro_rules!` macro, while payload-sensitive predicates remain handwritten.

This follows the direction discussed in [PR #949](https://github.com/crossterm-rs/crossterm/pull/949), where the tradeoff between boilerplate and an additional proc-macro dependency was discussed. [PR #970](https://github.com/crossterm-rs/crossterm/pull/970) subsequently made the dependency optional, but it was still enabled by default.

## Why

The generated methods are all simple variant checks, so requiring downstream users to compile `derive_more` and its proc-macro dependencies is disproportionate to the behavior being added.

The local macro keeps the declarations concise and consistent:

```rust
impl_is_variant! {
    Event {
        FocusGained => is_focus_gained,
        Key(..) => is_key,
        Mouse(..) => is_mouse,
    }
}
```

The variants previously marked `is_variant(ignore)`—`KeyCode::F`, `Char`, `Media`, and `Modifier`—are intentionally omitted from the macro. They already have handwritten payload-aware methods: `is_function_key`, `is_char`, `is_media_key`, and `is_modifier`. This avoids duplicate or conflicting methods while preserving their value-sensitive behavior.

## Compile-time comparison

These were clean, isolated builds on the same machine and toolchain:

| Benchmark | Local macro | `derive_more` | Difference |
| --- | ---: | ---: | ---: |
| Clean crossterm `cargo build` | 2.41s | 3.41s | +1.00s |
| Fresh consumer `cargo check` | 2.12s | 3.00s | +0.88s |

The `derive_more` build additionally compiled proc-macro dependencies including `syn`, `quote`, `convert_case`, `derive_more-impl`, and `derive_more`.

For context, [PR #949](https://github.com/crossterm-rs/crossterm/pull/949) measured the original fresh-project comparison at 1.851s versus 3.539s, and a clean M2 crate build at 2.016s versus 2.688s. Exact timings vary by toolchain and machine, but the direction is consistent.

## Validation

- `cargo fmt --check`
- `cargo test --all-targets --locked`
- `cargo test --no-default-features --all-targets --locked`
- `cargo test --all-features --all-targets --locked`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo doc --no-deps --all-features --locked`

cc @archseer @the-mikedavis
