### PR TITLE
fix chained queue docs usage example

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,7 @@
 //! ```
 //!
 //! The [queue](./trait.QueueableCommand.html) function returns itself, therefore you can use this to queue another
-//! command. Like `stdout.queue(Goto(5,5)).queue(Clear(ClearType::All))`.
+//! command. Like `stdout.queue(Goto(5,5))?.queue(Clear(ClearType::All))`.
 //!
 //! Macros:
 //!


### PR DESCRIPTION
### Add ? to queue chained usage example

Based on signature of queue function
it returns a **Result<**&mut Self>  not &mut Self,
so some sort of unwrapping is required to chain queue function calls,
furthermore the example with chained execute function features "**?**"

stdout.execute(Goto(5,5))**?**.execute(Clear(ClearType::All))